### PR TITLE
UX follow-up: start modal, focus flow, masked input routing and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,20 @@
 ## Project Rule
 - Always use the `brainstorming` skill before any creative or implementation work in this project.
 - When writing design docs, use Linear MCP to create related development issues in the ticket system.
+- Keep Linear MCP continuously up to date during both design and implementation:
+  - create issues for planned work,
+  - update issue status as work progresses,
+  - and link implemented changes back to the corresponding Linear tasks.
+
+## Branching and Pull Request Workflow
+- Always create a new feature branch from the latest `main`.
+- Keep each branch and PR small, focused, and reviewable.
+- All PRs must target `main`.
+- If `main` changes while a PR is under review, rebase the feature branch onto latest `main`.
+- After rebasing, push updates with `--force-with-lease`.
+- Independent features can be developed in parallel on separate branches.
+- Dependent features may temporarily stack on top of another feature branch, but must be rebased to latest `main` before opening the final PR.
+
+## Linear MCP Auth
+- Use OAuth-only authentication for Linear MCP (`codex mcp login linear`).
+- Do not use bearer token / API key auth methods (including `bearer_token_env_var`) for this project workflow.

--- a/docs/plans/2026-03-02-kuupeli-ux-route-and-masked-input-design.md
+++ b/docs/plans/2026-03-02-kuupeli-ux-route-and-masked-input-design.md
@@ -1,0 +1,110 @@
+# Kuupeli UX Route Split + Masked Input Design
+
+Date: 2026-03-02
+Status: Approved
+Scope: UX-focused restructuring of the game loop and navigation (no backend)
+
+## 1. Product UX Goal
+Reshape Kuupeli into a focused dictation game experience where:
+- `/play` is dedicated to the sentence loop only.
+- Story and model management are moved away from the play surface.
+- Sentence answering uses a custom masked letter field that supports continuous typing (for example `olipakerran` for `Olipa kerran`).
+
+## 2. Confirmed Decisions
+- Navigation model: route-first (`/play`, `/stories`, `/models`).
+- Main typing UX: custom masked sentence input, not plain text fields.
+- Backspace behavior: delete current slot and move cursor left, skipping separators.
+- Enter behavior: submit only when all fillable slots are filled.
+- Enter on incomplete sentence: no submit and cursor position stays unchanged.
+- Validation emphasis: word-level invalid highlighting.
+- On valid submit: star animation then auto-advance after about 700 ms.
+- Audio: autoplay on load when browser allows; replay is always available.
+- Answer strictness: case-insensitive, diacritics-sensitive (`a` != `ä`).
+- Punctuation: pre-rendered as static characters.
+- Story selection behavior for v1: always start from beginning.
+- Deferred feature: per-story resume/reset/rewind position management.
+
+## 3. Information Architecture
+### 3.1 `/play`
+Primary game canvas only:
+- top bar with navigation actions to `Stories` and `Models`
+- sentence progress indicator
+- replay control
+- masked sentence answer surface
+- submit and skip actions
+- retry/error feedback and star result feedback
+
+### 3.2 `/stories`
+Separate story management surface:
+- list available built-in and imported stories
+- select active story
+- import TXT/PDF story assets
+- selecting a story starts from sentence 1 in v1
+
+### 3.3 `/models`
+Separate model/profile management surface:
+- local runtime profile list
+- install/remove/select active profile
+- clear explanation that v1 profiles are local Kuupeli runtime profiles (not external downloadable cloud model bundles yet)
+
+## 4. `/play` Interaction Design
+### 4.1 Masked Sentence Surface
+- Each letter is represented by one fillable slot.
+- Spaces and punctuation are fixed tokens in the mask and are never typed.
+- Cursor visibly blinks on the active fillable slot.
+
+### 4.2 Input Flow
+- Typing letters fills the next fillable slot.
+- Pressing space is ignored.
+- Continuous typing auto-crosses word boundaries.
+- Backspace removes the current letter and moves left to previous fillable slot.
+
+### 4.3 Submit Rules
+- Enter attempts submit only if all fillable slots are populated.
+- If not complete, nothing is submitted and cursor stays where it is.
+- Submit button behavior matches Enter behavior.
+
+### 4.4 Retry Rules
+- On wrong submit, invalid words are highlighted at word level.
+- Tapping/clicking a highlighted word starts editing from that word’s first letter slot.
+- User can retry until sentence is correct.
+
+### 4.5 Success Rules
+- On correct answer, show star result animation.
+- Auto-advance to next sentence after about 700 ms.
+
+## 5. Error Handling UX
+- If autoplay is blocked, show subtle guidance to use replay.
+- Audio failures must be non-blocking; gameplay remains available.
+- Route/view transitions must not lose current unsent masked input state unexpectedly.
+
+## 6. Accessibility and Responsive Behavior
+- Keyboard and touch parity for all gameplay actions.
+- Visible focus styling for active slot and controls.
+- `aria-live` regions for important state changes (retry needed, success, stars, next sentence).
+- Mobile-first single-column layout for `/play`.
+- `/stories` and `/models` remain fully usable on narrow touch screens.
+
+## 7. Testing Requirements
+- Unit tests for masked input tokenization and cursor behavior.
+- Unit tests for keyboard behavior (space ignore, backspace traversal, Enter gating).
+- Unit tests for invalid word click-to-edit behavior.
+- Route-level integration tests for `/play`, `/stories`, `/models`.
+- E2E for full dictation loop with masked input and auto-advance.
+
+## 8. Non-Goals (This Iteration)
+- Grammar-mode parsing and grammar token gameplay.
+- Backend/cloud services.
+- Per-story resume/reset/rewind UX controls (tracked as future feature).
+
+## 9. Linear MCP Issue Map
+Linear MCP access is not available in this terminal session. Mirror the following items in Linear and keep synced during implementation:
+
+1. `UX-Play-Routes`: route split to `/play`, `/stories`, `/models`.
+2. `UX-Masked-Input-Core`: custom sentence mask engine with cursor and keyboard model.
+3. `UX-Play-Submit-Retry`: enter/submit gating, invalid-word highlight, click-to-edit flow.
+4. `UX-Play-Feedback`: star animation and timed auto-advance.
+5. `UX-Stories-View`: story selection/import view (start-from-beginning behavior).
+6. `UX-Models-View`: separate model/profile view and explanation copy.
+7. `UX-Regression-Tests`: unit/e2e coverage for new UX behavior.
+

--- a/docs/plans/2026-03-02-kuupeli-ux-route-and-masked-input-implementation-plan.md
+++ b/docs/plans/2026-03-02-kuupeli-ux-route-and-masked-input-implementation-plan.md
@@ -1,0 +1,402 @@
+# Kuupeli UX Route Split + Masked Input Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Implement the approved UX refresh by splitting gameplay and management into dedicated routes and replacing word text inputs with a custom masked sentence input engine.
+
+**Architecture:** Introduce route-level separation (`/play`, `/stories`, `/models`) and keep gameplay state centered in the play route. Build a deterministic masked-input engine that models fillable slots vs fixed separators, then map existing submit/retry/scoring/audio flow to the new interaction layer without backend dependencies.
+
+**Tech Stack:** React, TypeScript, Vite, React Router, Vitest, React Testing Library, Playwright
+
+---
+
+Implementation standards:
+- Use @superpowers:test-driven-development for all implementation steps.
+- Use @superpowers:systematic-debugging for any failing/unclear behavior.
+- Use @superpowers:verification-before-completion before completion claims.
+- Keep Linear MCP updated per `AGENTS.md`:
+  - create/update linked tasks for each task below,
+  - move statuses during execution,
+  - link commits/PR updates to the corresponding Linear issues.
+
+### Task 1: Add App Routing Shell (`/play`, `/stories`, `/models`)
+
+**Files:**
+- Modify: `package.json`
+- Modify: `src/main.tsx`
+- Create: `src/routes/AppRoutes.tsx`
+- Create: `src/routes/PlayPage.tsx`
+- Create: `src/routes/StoriesPage.tsx`
+- Create: `src/routes/ModelsPage.tsx`
+- Test: `tests/unit/app-routes.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AppRoutes } from '../../src/routes/AppRoutes'
+
+it('renders stories route heading', () => {
+  render(
+    <MemoryRouter initialEntries={['/stories']}>
+      <AppRoutes />
+    </MemoryRouter>
+  )
+  expect(screen.getByRole('heading', { name: /stories/i })).toBeInTheDocument()
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- tests/unit/app-routes.test.tsx`  
+Expected: FAIL because route components do not exist.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/play" element={<PlayPage />} />
+      <Route path="/stories" element={<StoriesPage />} />
+      <Route path="/models" element={<ModelsPage />} />
+      <Route path="*" element={<Navigate to="/play" replace />} />
+    </Routes>
+  )
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- tests/unit/app-routes.test.tsx`  
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add package.json src/main.tsx src/routes/AppRoutes.tsx src/routes/PlayPage.tsx src/routes/StoriesPage.tsx src/routes/ModelsPage.tsx tests/unit/app-routes.test.tsx
+git commit -m "feat: add route shell for play stories and models views"
+```
+
+### Task 2: Build Masked Sentence Engine Model
+
+**Files:**
+- Create: `src/play/maskedInputModel.ts`
+- Test: `tests/unit/masked-input-model.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import { buildMaskModel } from '../../src/play/maskedInputModel'
+
+it('marks letters as fillable and punctuation as static', () => {
+  const model = buildMaskModel('Olipa kerran.')
+  expect(model.fillableCount).toBe(11)
+  expect(model.tokens.at(-1)?.kind).toBe('static')
+  expect(model.tokens.at(-1)?.value).toBe('.')
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- tests/unit/masked-input-model.test.ts`  
+Expected: FAIL due to missing model module.
+
+**Step 3: Write minimal implementation**
+
+```ts
+export function buildMaskModel(sentence: string): MaskModel {
+  // produce token list: fillable slots for letters, static tokens for separators
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- tests/unit/masked-input-model.test.ts`  
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/play/maskedInputModel.ts tests/unit/masked-input-model.test.ts
+git commit -m "feat: add masked input token model for letters and separators"
+```
+
+### Task 3: Implement Custom Masked Input Component Keyboard Flow
+
+**Files:**
+- Create: `src/components/MaskedSentenceComposer.tsx`
+- Test: `tests/unit/masked-sentence-composer.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+it('fills slots by continuous typing and ignores spaces', async () => {
+  render(<MaskedSentenceComposer sentence="Olipa kerran" onChange={vi.fn()} />)
+  await userEvent.keyboard('olipa kerran')
+  expect(screen.getByTestId('mask-value')).toHaveTextContent('olipakerran')
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- tests/unit/masked-sentence-composer.test.tsx`  
+Expected: FAIL due to missing component.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+// hidden input + rendered slot surface
+// key handling: letters fill next slot, space ignored
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- tests/unit/masked-sentence-composer.test.tsx`  
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/components/MaskedSentenceComposer.tsx tests/unit/masked-sentence-composer.test.tsx
+git commit -m "feat: add masked sentence composer with continuous typing flow"
+```
+
+### Task 4: Add Backspace and Enter Submit-Gating Behavior
+
+**Files:**
+- Modify: `src/components/MaskedSentenceComposer.tsx`
+- Test: `tests/unit/masked-sentence-composer.test.tsx`
+
+**Step 1: Write the failing tests**
+
+```tsx
+it('backspace deletes current slot and moves left across separators', async () => {
+  // type + backspace and assert cursor/value state
+})
+
+it('does not submit on Enter when mask is incomplete', async () => {
+  // assert onSubmit not called and cursor unchanged
+})
+
+it('submits on Enter when all fillable slots are filled', async () => {
+  // assert onSubmit called once with collected value
+})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npm run test:unit -- tests/unit/masked-sentence-composer.test.tsx`  
+Expected: FAIL on new keyboard behavior assertions.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+// implement backspace traversal and enter gating rules
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npm run test:unit -- tests/unit/masked-sentence-composer.test.tsx`  
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/components/MaskedSentenceComposer.tsx tests/unit/masked-sentence-composer.test.tsx
+git commit -m "feat: implement backspace traversal and enter submit gating in masked composer"
+```
+
+### Task 5: Integrate Composer into `/play` and Apply Word-Level Retry Highlighting
+
+**Files:**
+- Modify: `src/routes/PlayPage.tsx`
+- Modify: `src/scoring/retryEvaluator.ts`
+- Modify: `src/scoring/starScorer.ts` (if needed for animation timing state only)
+- Test: `tests/unit/play-page-flow.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+it('highlights invalid words and focuses selected invalid word for editing', async () => {
+  // submit wrong answer, assert word-level invalid class,
+  // click invalid word, assert cursor starts at first letter of that word
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- tests/unit/play-page-flow.test.tsx`  
+Expected: FAIL due to missing integration behavior.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+// replace old per-word inputs with MaskedSentenceComposer
+// connect submit/retry/invalid-word click-to-edit flow
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- tests/unit/play-page-flow.test.tsx`  
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/routes/PlayPage.tsx src/scoring/retryEvaluator.ts src/scoring/starScorer.ts tests/unit/play-page-flow.test.tsx
+git commit -m "feat: integrate masked composer with word-level retry highlight flow"
+```
+
+### Task 6: Move Story and Model Management to Dedicated Views
+
+**Files:**
+- Modify: `src/routes/PlayPage.tsx`
+- Modify: `src/routes/StoriesPage.tsx`
+- Modify: `src/routes/ModelsPage.tsx`
+- Modify: `src/components/ImportControls.tsx`
+- Modify: `src/components/ModelManagerPanel.tsx`
+- Test: `tests/unit/stories-page.test.tsx`
+- Test: `tests/unit/models-page.test.tsx`
+
+**Step 1: Write failing tests**
+
+```tsx
+it('shows story management controls on /stories and not on /play', () => {})
+it('shows model manager only on /models', () => {})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npm run test:unit -- tests/unit/stories-page.test.tsx tests/unit/models-page.test.tsx`  
+Expected: FAIL because controls still live on play surface.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+// move import + model controls to dedicated route components
+// keep /play focused on game loop
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npm run test:unit -- tests/unit/stories-page.test.tsx tests/unit/models-page.test.tsx`  
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/routes/PlayPage.tsx src/routes/StoriesPage.tsx src/routes/ModelsPage.tsx src/components/ImportControls.tsx src/components/ModelManagerPanel.tsx tests/unit/stories-page.test.tsx tests/unit/models-page.test.tsx
+git commit -m "feat: split story and model management into dedicated routes"
+```
+
+### Task 7: Add Success Animation Timing and Auto-Advance
+
+**Files:**
+- Modify: `src/routes/PlayPage.tsx`
+- Modify: `src/styles.css`
+- Test: `tests/unit/play-page-success-transition.test.tsx`
+
+**Step 1: Write the failing test**
+
+```tsx
+it('auto-advances after successful submit with transition delay', async () => {
+  vi.useFakeTimers()
+  // submit correct answer
+  // assert sentence index advances after ~700ms
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- tests/unit/play-page-success-transition.test.tsx`  
+Expected: FAIL due to missing delayed transition behavior.
+
+**Step 3: Write minimal implementation**
+
+```tsx
+// on success set transition state + delay next sentence advance by 700ms
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- tests/unit/play-page-success-transition.test.tsx`  
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/routes/PlayPage.tsx src/styles.css tests/unit/play-page-success-transition.test.tsx
+git commit -m "feat: add success star transition and timed auto-advance"
+```
+
+### Task 8: Update E2E Coverage for New Route and Input UX
+
+**Files:**
+- Modify: `tests/e2e/story-flow.spec.ts`
+- Modify: `tests/e2e/mobile-story-flow.spec.ts`
+- Create: `tests/e2e/routes-navigation.spec.ts`
+- Create: `tests/e2e/masked-input-flow.spec.ts`
+
+**Step 1: Write failing e2e tests**
+
+```ts
+test('typing contiguous letters fills masked sentence across spaces', async ({ page }) => {})
+test('play page links to stories and models routes', async ({ page }) => {})
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npm run test:e2e -- tests/e2e/masked-input-flow.spec.ts tests/e2e/routes-navigation.spec.ts`  
+Expected: FAIL before route/input UX changes are fully wired.
+
+**Step 3: Write minimal implementation updates**
+
+```ts
+// adjust selectors and assertions to route-based UX and masked input flow
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npm run test:e2e -- tests/e2e/masked-input-flow.spec.ts tests/e2e/routes-navigation.spec.ts`  
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add tests/e2e/story-flow.spec.ts tests/e2e/mobile-story-flow.spec.ts tests/e2e/routes-navigation.spec.ts tests/e2e/masked-input-flow.spec.ts
+git commit -m "test: add e2e coverage for masked input flow and route navigation"
+```
+
+### Task 9: Final Verification + Docs/Linear Sync
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/plans/2026-03-02-kuupeli-ux-route-and-masked-input-design.md` (only if final deltas exist)
+
+**Step 1: Verify CI locally**
+
+Run: `npm run ci`  
+Expected: all unit and e2e tests PASS.
+
+**Step 2: Update user-facing docs**
+
+Document:
+- new route structure,
+- masked input behavior (space ignore, Enter gating),
+- v1 story selection start behavior.
+
+**Step 3: Sync Linear MCP**
+
+For each linked UX ticket:
+- set status to done/in review as appropriate,
+- link commit hashes and PR URL,
+- add short implementation summary.
+
+**Step 4: Commit docs update**
+
+```bash
+git add README.md docs/plans/2026-03-02-kuupeli-ux-route-and-masked-input-design.md
+git commit -m "docs: update ux flow and route behavior documentation"
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "espeak-ng": "^1.0.2",
         "idb": "^8.0.3",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.13.1"
       },
       "devDependencies": {
         "@playwright/test": "^1.54.2",
@@ -3505,6 +3506,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
@@ -5580,6 +5594,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -5901,6 +5953,12 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "espeak-ng": "^1.0.2",
     "idb": "^8.0.3",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.13.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,23 @@
-import { useEffect, useMemo, useState } from 'react'
-import { ImportControls } from './components/ImportControls'
-import { MaskedSentenceInput } from './components/MaskedSentenceInput'
-import { ModelManagerPanel } from './components/ModelManagerPanel'
-import { logError, logEvent } from './observability/devLogger'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { MaskedSentenceComposer, type MaskedSentenceComposerValue } from './components/MaskedSentenceComposer'
 import { ReplayButton } from './components/ReplayButton'
+import { StartModal } from './components/StartModal'
 import { SubmitButton } from './components/SubmitButton'
 import { STARTER_SENTENCES } from './data/starterSentences'
+import { logError, logEvent } from './observability/devLogger'
 import { findInvalidWords } from './scoring/retryEvaluator'
 import { scoreStars } from './scoring/starScorer'
 import { playSentenceAudio } from './tts/playback'
 
 type ThemeMode = 'dark' | 'light'
 const THEME_STORAGE_KEY = 'kuupeli-theme'
+const SUCCESS_ADVANCE_DELAY_MS = 700
+
+const EMPTY_MASK_VALUE: MaskedSentenceComposerValue = {
+  compact: '',
+  spaced: '',
+  isComplete: false
+}
 
 function normalizeWord(word: string) {
   return word.toLocaleLowerCase('fi-FI').replace(/[.,!?;:()"']/g, '')
@@ -42,20 +48,27 @@ export default function App() {
   const [theme, setTheme] = useState<ThemeMode>(() => readPersistedTheme())
   const [sentenceIndex, setSentenceIndex] = useState(0)
   const currentSentence = STARTER_SENTENCES[sentenceIndex]
+  const [maskValue, setMaskValue] = useState<MaskedSentenceComposerValue>(EMPTY_MASK_VALUE)
+  const [attemptCount, setAttemptCount] = useState(0)
+  const [stars, setStars] = useState<1 | 2 | 3 | null>(null)
+  const [invalidIndexes, setInvalidIndexes] = useState<number[]>([])
+  const [activeWordIndex, setActiveWordIndex] = useState<number | null>(null)
+  const [audioError, setAudioError] = useState<string | null>(null)
+  const [isAdvancing, setIsAdvancing] = useState(false)
+  const [isStartModalOpen, setIsStartModalOpen] = useState(true)
+  const [hasSessionStarted, setHasSessionStarted] = useState(false)
+  const [focusSignal, setFocusSignal] = useState(0)
+  const transitionTimerRef = useRef<number | null>(null)
+  const lastAutoplayKeyRef = useRef<string | null>(null)
 
   const targetWords = useMemo(
     () => currentSentence.split(/\s+/).map((word) => normalizeWord(word)).filter(Boolean),
     [currentSentence]
   )
 
-  const [answers, setAnswers] = useState<string[]>(() => targetWords.map(() => ''))
-  const [attemptCount, setAttemptCount] = useState(0)
-  const [stars, setStars] = useState<1 | 2 | 3 | null>(null)
-  const [invalidIndexes, setInvalidIndexes] = useState<number[]>([])
-  const [replayCount, setReplayCount] = useState(0)
-  const [audioError, setAudioError] = useState<string | null>(null)
-
   const isComplete = stars !== null
+  const isSubmitDisabled = !maskValue.isComplete || isAdvancing
+  const isSkipDisabled = isAdvancing
 
   useEffect(() => {
     logEvent('theme', 'applying_theme', { theme })
@@ -71,22 +84,69 @@ export default function App() {
   }, [theme])
 
   useEffect(() => {
-    setAnswers(targetWords.map(() => ''))
+    setMaskValue(EMPTY_MASK_VALUE)
     setAttemptCount(0)
     setStars(null)
     setInvalidIndexes([])
+    setActiveWordIndex(null)
     setAudioError(null)
+    setIsAdvancing(false)
+
+    if (transitionTimerRef.current !== null) {
+      window.clearTimeout(transitionTimerRef.current)
+      transitionTimerRef.current = null
+    }
+
     logEvent('round', 'loaded', {
       sentenceIndex,
       sentenceCount: STARTER_SENTENCES.length,
       targetWordCount: targetWords.length,
       sentence: currentSentence
     })
-  }, [targetWords])
+  }, [currentSentence, sentenceIndex, targetWords.length])
 
   useEffect(() => {
-    if (typeof window === 'undefined' || !('speechSynthesis' in window) || typeof SpeechSynthesisUtterance === 'undefined') {
-      logEvent('audio', 'autoplay_skipped_api_unavailable')
+    if (!hasSessionStarted) {
+      return
+    }
+
+    setFocusSignal((current) => current + 1)
+  }, [currentSentence, hasSessionStarted, sentenceIndex])
+
+  useEffect(() => {
+    if (!isAdvancing) {
+      return
+    }
+
+    transitionTimerRef.current = window.setTimeout(() => {
+      transitionTimerRef.current = null
+      if (sentenceIndex >= STARTER_SENTENCES.length - 1) {
+        setIsAdvancing(false)
+        logEvent('round', 'success_transition_completed_last_sentence', {
+          sentenceIndex,
+          transitionDelayMs: SUCCESS_ADVANCE_DELAY_MS
+        })
+        return
+      }
+
+      setSentenceIndex((current) => Math.min(current + 1, STARTER_SENTENCES.length - 1))
+      logEvent('round', 'auto_advanced_after_success', {
+        fromSentenceIndex: sentenceIndex,
+        toSentenceIndex: sentenceIndex + 1,
+        transitionDelayMs: SUCCESS_ADVANCE_DELAY_MS
+      })
+    }, SUCCESS_ADVANCE_DELAY_MS)
+
+    return () => {
+      if (transitionTimerRef.current !== null) {
+        window.clearTimeout(transitionTimerRef.current)
+        transitionTimerRef.current = null
+      }
+    }
+  }, [isAdvancing, sentenceIndex])
+
+  useEffect(() => {
+    if (!hasSessionStarted) {
       return
     }
 
@@ -95,6 +155,13 @@ export default function App() {
       return
     }
 
+    const autoplayKey = `${sentenceIndex}:${currentSentence}`
+    if (lastAutoplayKeyRef.current === autoplayKey) {
+      logEvent('audio', 'autoplay_skipped_duplicate_effect', { sentenceIndex })
+      return
+    }
+
+    lastAutoplayKeyRef.current = autoplayKey
     let cancelled = false
 
     const autoplayCurrentSentence = async () => {
@@ -107,11 +174,8 @@ export default function App() {
         }
       } catch (error) {
         if (!cancelled) {
-          setAudioError(null)
-          logEvent('audio', 'autoplay_failed', {
-            sentenceIndex,
-            reason: error instanceof Error ? error.message : 'Unknown error'
-          })
+          setAudioError('Audio playback is unavailable on this browser.')
+          logError('audio', 'autoplay_failed', error, { sentenceIndex })
         }
       }
     }
@@ -121,25 +185,43 @@ export default function App() {
     return () => {
       cancelled = true
     }
-  }, [currentSentence])
+  }, [currentSentence, hasSessionStarted, sentenceIndex])
 
-  function handleSubmit() {
+  useEffect(() => {
+    return () => {
+      if (transitionTimerRef.current !== null) {
+        window.clearTimeout(transitionTimerRef.current)
+      }
+    }
+  }, [])
+
+  function submitAnswer(answer: string, source: 'button' | 'keyboard') {
+    if (isAdvancing) {
+      logEvent('round', 'submit_ignored_while_advancing', {
+        sentenceIndex,
+        source
+      })
+      return
+    }
+
     const nextAttempt = attemptCount + 1
     setAttemptCount(nextAttempt)
 
-    const actual = answers.map((word) => normalizeWord(word)).join(' ')
     const expected = targetWords.join(' ')
-    const invalid = findInvalidWords(expected, actual)
+    const invalid = findInvalidWords(expected, answer)
     logEvent('round', 'submitted', {
       sentenceIndex,
       attempt: nextAttempt,
-      invalidCount: invalid.length
+      invalidCount: invalid.length,
+      source
     })
 
     if (invalid.length === 0) {
       const nextStars = scoreStars(nextAttempt)
       setStars(nextStars)
       setInvalidIndexes([])
+      setActiveWordIndex(null)
+      setIsAdvancing(true)
       logEvent('round', 'completed', {
         sentenceIndex,
         attempt: nextAttempt,
@@ -150,6 +232,8 @@ export default function App() {
 
     setStars(null)
     setInvalidIndexes(invalid)
+    setActiveWordIndex(invalid[0] ?? null)
+    setIsAdvancing(false)
     logEvent('round', 'needs_retry', {
       sentenceIndex,
       attempt: nextAttempt,
@@ -158,30 +242,25 @@ export default function App() {
   }
 
   async function handleReplay() {
-    const nextReplayCount = replayCount + 1
-    setReplayCount(nextReplayCount)
-    logEvent('audio', 'replay_clicked', {
-      sentenceIndex,
-      replayCount: nextReplayCount
-    })
+    setFocusSignal((current) => current + 1)
+    logEvent('audio', 'replay_clicked', { sentenceIndex })
 
     try {
       await playSentenceAudio(currentSentence)
       setAudioError(null)
-      logEvent('audio', 'replay_completed', {
-        sentenceIndex,
-        replayCount: nextReplayCount
-      })
+      logEvent('audio', 'replay_completed', { sentenceIndex })
     } catch (error) {
       setAudioError('Audio playback is unavailable on this browser.')
-      logError('audio', 'replay_failed', error, {
-        sentenceIndex,
-        replayCount: nextReplayCount
-      })
+      logError('audio', 'replay_failed', error, { sentenceIndex })
     }
   }
 
   function handleNextSentence() {
+    if (isAdvancing) {
+      logEvent('round', 'skip_ignored_while_advancing', { sentenceIndex })
+      return
+    }
+
     if (sentenceIndex < STARTER_SENTENCES.length - 1) {
       logEvent('round', isComplete ? 'next_sentence_clicked' : 'skip_sentence_clicked', {
         fromSentenceIndex: sentenceIndex,
@@ -194,99 +273,120 @@ export default function App() {
     logEvent('round', 'navigation_ignored_last_sentence', { sentenceIndex })
   }
 
+  function handleStartSession() {
+    setIsStartModalOpen(false)
+    setHasSessionStarted(true)
+    setFocusSignal((current) => current + 1)
+    logEvent('session', 'start_clicked', { sentenceIndex })
+  }
+
+  const handleMaskValueChange = useCallback(
+    (nextValue: MaskedSentenceComposerValue) => {
+      setMaskValue(nextValue)
+      setActiveWordIndex(null)
+      logEvent('input', 'mask_updated', {
+        sentenceIndex,
+        compactLength: nextValue.compact.length,
+        isComplete: nextValue.isComplete
+      })
+    },
+    [sentenceIndex]
+  )
+
+  const handleKeyboardSubmit = useCallback(
+    (value: string) => {
+      submitAnswer(value, 'keyboard')
+    },
+    [attemptCount, sentenceIndex, targetWords]
+  )
+
+  const handleIncompleteKeyboardSubmit = useCallback(() => {
+    logEvent('round', 'submit_ignored_incomplete', {
+      sentenceIndex,
+      source: 'keyboard'
+    })
+  }, [sentenceIndex])
+
   return (
     <main className="app-shell">
       <header className="app-header">
         <h1>Kuupeli</h1>
-        <button
-          type="button"
-          className="theme-toggle"
-          aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-          onClick={() => {
-            logEvent('theme', 'toggle_clicked', {
-              fromTheme: theme,
-              toTheme: theme === 'dark' ? 'light' : 'dark'
-            })
-            setTheme((current) => (current === 'dark' ? 'light' : 'dark'))
-          }}
-        >
-          {theme === 'dark' ? 'Light mode' : 'Dark mode'}
-        </button>
+        <div className="header-actions">
+          <a href="/stories" className="header-link">
+            Stories
+          </a>
+          <a href="/models" className="header-link">
+            Models
+          </a>
+          <button
+            type="button"
+            className="theme-toggle"
+            aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            onClick={() => {
+              logEvent('theme', 'toggle_clicked', {
+                fromTheme: theme,
+                toTheme: theme === 'dark' ? 'light' : 'dark'
+              })
+              setTheme((current) => (current === 'dark' ? 'light' : 'dark'))
+            }}
+          >
+            {theme === 'dark' ? 'Light mode' : 'Dark mode'}
+          </button>
+        </div>
       </header>
       <p aria-live="polite">
         Starter Pack: {sentenceIndex + 1}/{STARTER_SENTENCES.length}
       </p>
 
-      <section className="round-panel">
-        <MaskedSentenceInput sentence={currentSentence} />
-
+      <section className={`round-panel${isAdvancing ? ' round-panel-success' : ''}`}>
         <ReplayButton
           onReplay={() => {
             void handleReplay()
           }}
         />
-        <p aria-live="polite">Replay count: {replayCount}</p>
         {audioError && <p role="alert">{audioError}</p>}
 
-        <form
-          onSubmit={(event) => {
-            event.preventDefault()
-            handleSubmit()
-          }}
-        >
-          <div className="word-grid">
-            {targetWords.map((_, index) => {
-              const label = `Word ${index + 1}`
-              const isInvalid = invalidIndexes.includes(index)
+        <MaskedSentenceComposer
+          sentence={currentSentence}
+          invalidWordIndexes={invalidIndexes}
+          activeWordIndex={activeWordIndex}
+          focusSignal={focusSignal}
+          onValueChange={handleMaskValueChange}
+          onSubmit={handleKeyboardSubmit}
+          onIncompleteSubmit={handleIncompleteKeyboardSubmit}
+        />
 
-              return (
-                <label key={label} className={isInvalid ? 'word-input invalid' : 'word-input'}>
-                  <span>{label}</span>
-                  <input
-                    aria-label={label}
-                    value={answers[index] ?? ''}
-                    onChange={(event) => {
-                      const next = [...answers]
-                      next[index] = event.target.value
-                      setAnswers(next)
-                      logEvent('input', 'word_updated', {
-                        sentenceIndex,
-                        wordIndex: index,
-                        valueLength: event.target.value.length
-                      })
-                    }}
-                  />
-                </label>
-              )
-            })}
-          </div>
+        <div className="round-actions">
+          <SubmitButton
+            disabled={isSubmitDisabled}
+            onSubmit={() => {
+              if (isSubmitDisabled) {
+                logEvent('round', 'submit_ignored_button_disabled', {
+                  sentenceIndex,
+                  isComplete: maskValue.isComplete,
+                  isAdvancing
+                })
+                return
+              }
 
-          <SubmitButton disabled={false} onSubmit={handleSubmit} />
-        </form>
+              submitAnswer(maskValue.spaced, 'button')
+            }}
+          />
+
+          {sentenceIndex < STARTER_SENTENCES.length - 1 && (
+            <button type="button" className="skip-sentence-button" onClick={handleNextSentence} disabled={isSkipDisabled}>
+              Skip sentence
+            </button>
+          )}
+        </div>
 
         {isComplete && <p aria-live="polite">Stars: {stars}</p>}
-        {sentenceIndex < STARTER_SENTENCES.length - 1 && (
-          <button type="button" onClick={handleNextSentence}>
-            {isComplete ? 'Next sentence' : 'Skip sentence'}
-          </button>
-        )}
         {!isComplete && invalidIndexes.length > 0 && (
           <p aria-live="polite">Fix highlighted words: {invalidIndexes.join(', ')}</p>
         )}
       </section>
 
-      <section className="tools-panel">
-        <ImportControls
-          onSelect={(file) => {
-            logEvent('ingestion', 'file_selected', {
-              fileName: file.name,
-              fileType: file.type,
-              fileSize: file.size
-            })
-          }}
-        />
-        <ModelManagerPanel />
-      </section>
+      {isStartModalOpen && <StartModal onStart={handleStartSession} />}
     </main>
   )
 }

--- a/src/components/MaskedSentenceComposer.tsx
+++ b/src/components/MaskedSentenceComposer.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  buildMaskModel,
+  extractWordsFromSlots,
+  getFirstFillableIndexForWord,
+  getNextFillableIndex,
+  getPreviousFillableIndex,
+  isFillableLetter
+} from '../play/maskedInputModel'
+
+export interface MaskedSentenceComposerValue {
+  compact: string
+  spaced: string
+  isComplete: boolean
+}
+
+interface MaskedSentenceComposerProps {
+  sentence: string
+  onSubmit: (value: string) => void
+  invalidWordIndexes?: number[]
+  onValueChange?: (value: MaskedSentenceComposerValue) => void
+  onIncompleteSubmit?: () => void
+  activeWordIndex?: number | null
+  focusSignal?: number
+}
+
+export function MaskedSentenceComposer({
+  sentence,
+  onSubmit,
+  invalidWordIndexes = [],
+  onValueChange,
+  onIncompleteSubmit,
+  activeWordIndex = null,
+  focusSignal
+}: MaskedSentenceComposerProps) {
+  const model = useMemo(() => buildMaskModel(sentence), [sentence])
+  const [slots, setSlots] = useState<string[]>(() => Array(model.fillableCount).fill(''))
+  const [cursorIndex, setCursorIndex] = useState(0)
+  const surfaceRef = useRef<HTMLDivElement>(null)
+  const previousFocusSignalRef = useRef<number | undefined>(focusSignal)
+
+  useEffect(() => {
+    setSlots(Array(model.fillableCount).fill(''))
+    setCursorIndex(0)
+  }, [model])
+
+  useEffect(() => {
+    const compact = slots.join('')
+    const spaced = extractWordsFromSlots(model, slots).join(' ')
+    onValueChange?.({
+      compact,
+      spaced,
+      isComplete: slots.every((slot) => slot.length > 0)
+    })
+  }, [model, onValueChange, slots])
+
+  useEffect(() => {
+    if (activeWordIndex === null) {
+      return
+    }
+
+    setCursorIndex(getFirstFillableIndexForWord(model, activeWordIndex))
+  }, [activeWordIndex, model])
+
+  useEffect(() => {
+    if (focusSignal === undefined || focusSignal === previousFocusSignalRef.current) {
+      return
+    }
+
+    previousFocusSignalRef.current = focusSignal
+    surfaceRef.current?.focus()
+  }, [focusSignal])
+
+  function handleLetterInput(letter: string) {
+    if (model.fillableCount === 0) {
+      return
+    }
+
+    const normalized = letter.toLocaleLowerCase('fi-FI')
+    setSlots((current) => {
+      const next = [...current]
+      next[cursorIndex] = normalized
+      return next
+    })
+    setCursorIndex((current) => getNextFillableIndex(model, current))
+  }
+
+  function handleBackspace() {
+    if (model.fillableCount === 0) {
+      return
+    }
+
+    setSlots((current) => {
+      const next = [...current]
+      next[cursorIndex] = ''
+      return next
+    })
+    setCursorIndex((current) => getPreviousFillableIndex(model, current))
+  }
+
+  function handleSubmitFromKeyboard() {
+    if (slots.some((slot) => slot.length === 0)) {
+      onIncompleteSubmit?.()
+      return
+    }
+
+    onSubmit(extractWordsFromSlots(model, slots).join(' '))
+  }
+
+  return (
+    <div className="masked-composer">
+      <div
+        ref={surfaceRef}
+        tabIndex={0}
+        role="textbox"
+        aria-label="Sentence answer input"
+        className="masked-composer-surface"
+        onClick={() => {
+          surfaceRef.current?.focus()
+        }}
+        onKeyDown={(event) => {
+          if (event.key === ' ') {
+            event.preventDefault()
+            return
+          }
+
+          if (event.key === 'Backspace') {
+            event.preventDefault()
+            handleBackspace()
+            return
+          }
+
+          if (event.key === 'Enter') {
+            event.preventDefault()
+            handleSubmitFromKeyboard()
+            return
+          }
+
+          if (event.key.length === 1 && isFillableLetter(event.key)) {
+            event.preventDefault()
+            handleLetterInput(event.key)
+          }
+        }}
+      >
+        {model.tokens.map((token, tokenIndex) => {
+          if (token.kind === 'static') {
+            return (
+              <span key={`token-${tokenIndex}`} className="mask-static">
+                {token.value === ' ' ? '\u00A0' : token.value}
+              </span>
+            )
+          }
+
+          const value = slots[token.slotIndex] || '_'
+          const isActive = token.slotIndex === cursorIndex
+          const isInvalid = invalidWordIndexes.includes(token.wordIndex)
+
+          return (
+            <button
+              key={`slot-${token.slotIndex}`}
+              data-testid={`slot-${token.slotIndex}`}
+              type="button"
+              className={`mask-slot${isActive ? ' active' : ''}${isInvalid ? ' invalid' : ''}`}
+              onClick={() => {
+                setCursorIndex(token.slotIndex)
+                surfaceRef.current?.focus()
+              }}
+            >
+              {value}
+            </button>
+          )
+        })}
+      </div>
+
+      <output data-testid="mask-value" hidden>
+        {slots.join('')}
+      </output>
+      <output data-testid="mask-cursor" hidden>
+        {cursorIndex}
+      </output>
+    </div>
+  )
+}

--- a/src/components/StartModal.tsx
+++ b/src/components/StartModal.tsx
@@ -1,0 +1,16 @@
+interface StartModalProps {
+  onStart: () => void
+}
+
+export function StartModal({ onStart }: StartModalProps) {
+  return (
+    <div className="start-modal" role="dialog" aria-modal="true" aria-labelledby="start-modal-title">
+      <div className="start-modal-card">
+        <h2 id="start-modal-title">Oletko valmis ensimmäiseen lauseeseen?</h2>
+        <button type="button" className="start-modal-button" onClick={onStart}>
+          Aloita
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
-import App from './App'
+import { BrowserRouter } from 'react-router-dom'
 import { logError, logEvent } from './observability/devLogger'
 import { registerServiceWorker } from './pwa/registerServiceWorker'
+import { AppRoutes } from './routes/AppRoutes'
 import './styles.css'
 
 const container = document.getElementById('root')
@@ -22,7 +23,9 @@ registerServiceWorker({
 
 createRoot(container).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <AppRoutes />
+    </BrowserRouter>
   </React.StrictMode>
 )
 

--- a/src/play/maskedInputModel.ts
+++ b/src/play/maskedInputModel.ts
@@ -1,0 +1,93 @@
+export type MaskToken =
+  | {
+      kind: 'fillable'
+      value: string
+      slotIndex: number
+      wordIndex: number
+    }
+  | {
+      kind: 'static'
+      value: string
+    }
+
+export interface MaskModel {
+  sentence: string
+  tokens: MaskToken[]
+  fillableCount: number
+  wordCount: number
+}
+
+const LETTER_PATTERN = /^\p{L}$/u
+
+export function isFillableLetter(char: string): boolean {
+  return LETTER_PATTERN.test(char)
+}
+
+export function buildMaskModel(sentence: string): MaskModel {
+  const tokens: MaskToken[] = []
+  let slotIndex = 0
+  let wordIndex = 0
+  let insideWord = false
+
+  for (const char of Array.from(sentence)) {
+    if (isFillableLetter(char)) {
+      tokens.push({
+        kind: 'fillable',
+        value: char,
+        slotIndex,
+        wordIndex
+      })
+      slotIndex += 1
+      insideWord = true
+      continue
+    }
+
+    tokens.push({ kind: 'static', value: char })
+    if (/\s/.test(char) && insideWord) {
+      wordIndex += 1
+      insideWord = false
+    }
+  }
+
+  return {
+    sentence,
+    tokens,
+    fillableCount: slotIndex,
+    wordCount: insideWord ? wordIndex + 1 : wordIndex
+  }
+}
+
+export function extractWordsFromSlots(model: MaskModel, slots: string[]): string[] {
+  const words = Array.from({ length: model.wordCount }, () => '')
+
+  for (const token of model.tokens) {
+    if (token.kind !== 'fillable') {
+      continue
+    }
+
+    words[token.wordIndex] += slots[token.slotIndex] ?? ''
+  }
+
+  return words
+}
+
+export function getNextFillableIndex(model: MaskModel, currentIndex: number): number {
+  if (model.fillableCount === 0) {
+    return 0
+  }
+
+  return Math.min(currentIndex + 1, model.fillableCount - 1)
+}
+
+export function getPreviousFillableIndex(_model: MaskModel, currentIndex: number): number {
+  return Math.max(currentIndex - 1, 0)
+}
+
+export function getFirstFillableIndexForWord(model: MaskModel, wordIndex: number): number {
+  const token = model.tokens.find((item) => item.kind === 'fillable' && item.wordIndex === wordIndex)
+  if (!token || token.kind !== 'fillable') {
+    return 0
+  }
+
+  return token.slotIndex
+}

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,0 +1,16 @@
+import { Navigate, Route, Routes } from 'react-router-dom'
+import { ModelsPage } from './ModelsPage'
+import { PlayPage } from './PlayPage'
+import { StoriesPage } from './StoriesPage'
+
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/play" element={<PlayPage />} />
+      <Route path="/stories" element={<StoriesPage />} />
+      <Route path="/models" element={<ModelsPage />} />
+      <Route path="/" element={<Navigate to="/play" replace />} />
+      <Route path="*" element={<Navigate to="/play" replace />} />
+    </Routes>
+  )
+}

--- a/src/routes/ModelsPage.tsx
+++ b/src/routes/ModelsPage.tsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom'
+import { ModelManagerPanel } from '../components/ModelManagerPanel'
+
+export function ModelsPage() {
+  return (
+    <main className="app-shell">
+      <header className="app-header">
+        <h1>Models</h1>
+        <Link to="/play">Back to Play</Link>
+      </header>
+
+      <section className="tools-panel">
+        <ModelManagerPanel />
+      </section>
+    </main>
+  )
+}

--- a/src/routes/PlayPage.tsx
+++ b/src/routes/PlayPage.tsx
@@ -1,0 +1,5 @@
+import App from '../App'
+
+export function PlayPage() {
+  return <App />
+}

--- a/src/routes/StoriesPage.tsx
+++ b/src/routes/StoriesPage.tsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom'
+import { ImportControls } from '../components/ImportControls'
+import { logEvent } from '../observability/devLogger'
+
+export function StoriesPage() {
+  return (
+    <main className="app-shell">
+      <header className="app-header">
+        <h1>Stories</h1>
+        <Link to="/play">Back to Play</Link>
+      </header>
+
+      <section className="tools-panel">
+        <p>Story selection and import. In v1, selecting a story starts from sentence 1.</p>
+        <ImportControls
+          onSelect={(file) => {
+            logEvent('stories', 'story_file_selected', {
+              fileName: file.name,
+              fileType: file.type,
+              fileSize: file.size
+            })
+          }}
+        />
+      </section>
+    </main>
+  )
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -56,6 +56,21 @@ body {
   gap: 1rem;
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.header-link {
+  color: var(--text-color);
+  text-decoration: none;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.92rem;
+}
+
 .theme-toggle {
   border: 1px solid var(--panel-border);
   background: transparent;
@@ -76,9 +91,141 @@ body {
   gap: 0.75rem;
 }
 
+.round-panel-success {
+  animation: round-success-pulse 700ms ease;
+}
+
+@keyframes round-success-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(156, 196, 255, 0);
+  }
+  25% {
+    box-shadow: 0 0 0 4px rgba(156, 196, 255, 0.35);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(156, 196, 255, 0);
+  }
+}
+
 .masked-sentence {
   font-size: 1.2rem;
   letter-spacing: 0.07em;
+}
+
+.masked-composer {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.masked-composer-surface {
+  border: 1px solid var(--input-border);
+  border-radius: 12px;
+  padding: 0.85rem;
+  background: var(--input-background);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.32rem;
+}
+
+.masked-composer-surface:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.mask-static {
+  font-size: 1.15rem;
+  letter-spacing: 0.04em;
+  display: inline-flex;
+  align-items: center;
+}
+
+.mask-slot {
+  min-width: 1.2rem;
+  border: none;
+  border-bottom: 2px solid var(--input-border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-color);
+  font: inherit;
+  font-size: 1.08rem;
+  line-height: 1.5rem;
+  padding: 0 0.08rem;
+  text-align: center;
+  cursor: text;
+}
+
+.mask-slot.active {
+  border-bottom-color: var(--accent);
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+
+.mask-slot.invalid {
+  border-bottom-color: #ff6f7f;
+  color: #ff8d99;
+}
+
+.round-actions {
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  gap: 0.6rem;
+}
+
+.round-actions button {
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--panel-background), #fff 6%);
+  color: var(--text-color);
+  font: inherit;
+  padding: 0.62rem 0.85rem;
+  cursor: pointer;
+}
+
+.round-actions button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.skip-sentence-button {
+  font-size: 0.92rem;
+}
+
+.start-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(3, 8, 16, 0.9);
+  display: grid;
+  place-items: center;
+  padding: 1.2rem;
+}
+
+.start-modal-card {
+  width: min(520px, 100%);
+  background: var(--panel-background);
+  border: 1px solid var(--panel-border);
+  border-radius: 14px;
+  padding: 1.3rem;
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+}
+
+.start-modal-card h2 {
+  margin: 0;
+  font-size: clamp(1.2rem, 4vw, 1.6rem);
+  line-height: 1.3;
+}
+
+.start-modal-button {
+  justify-self: center;
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel-background), #fff 10%);
+  color: var(--text-color);
+  font: inherit;
+  font-size: 1rem;
+  padding: 0.6rem 1.5rem;
+  cursor: pointer;
 }
 
 .word-grid {
@@ -114,5 +261,9 @@ body {
   .app-header {
     align-items: start;
     flex-direction: column;
+  }
+
+  .header-actions {
+    flex-wrap: wrap;
   }
 }

--- a/tests/e2e/masked-input-flow.spec.ts
+++ b/tests/e2e/masked-input-flow.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from './guardedTest'
+
+test('typing contiguous letters fills masked sentence across spaces', async ({ page }) => {
+  await page.goto('/play')
+  await page.getByRole('button', { name: 'Aloita' }).click()
+
+  const composer = page.getByLabel('Sentence answer input')
+  await composer.focus()
+  await composer.pressSequentially('olipa kerran')
+
+  await page.getByRole('button', { name: 'Submit' }).click()
+  await expect(page.getByText('Stars: 3')).toBeVisible()
+})

--- a/tests/e2e/mobile-story-flow.spec.ts
+++ b/tests/e2e/mobile-story-flow.spec.ts
@@ -3,10 +3,12 @@ import { expect, test } from './guardedTest'
 test('mobile story round supports replay and scoring', async ({ page }) => {
   await page.goto('/')
 
+  await page.getByRole('button', { name: 'Aloita' }).click()
   await page.getByRole('button', { name: 'Replay' }).click()
-  await page.getByLabel('Word 1').fill('Olipa')
-  await page.getByLabel('Word 2').fill('kerran')
-  await page.getByRole('button', { name: 'Submit' }).click()
+  const composer = page.getByLabel('Sentence answer input')
+  await composer.focus()
+  await composer.pressSequentially('olipakerran')
+  await composer.press('Enter')
 
   await expect(page.getByText(/Stars:/)).toBeVisible()
 })

--- a/tests/e2e/replay-audio.spec.ts
+++ b/tests/e2e/replay-audio.spec.ts
@@ -23,6 +23,7 @@ test('replay outputs non-empty audio payload', async ({ page }) => {
   })
 
   await page.goto('/')
+  await page.getByRole('button', { name: 'Aloita' }).click()
   infoLogs.length = 0
 
   await page.getByRole('button', { name: 'Replay' }).click()

--- a/tests/e2e/routes-navigation.spec.ts
+++ b/tests/e2e/routes-navigation.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from './guardedTest'
+
+test('play page links to stories and models routes', async ({ page }) => {
+  await page.goto('/play')
+  await page.getByRole('button', { name: 'Aloita' }).click()
+
+  await page.getByRole('link', { name: 'Stories' }).click()
+  await expect(page.getByRole('heading', { name: /stories/i })).toBeVisible()
+  await expect(page.getByLabel('Import File')).toBeVisible()
+
+  await page.getByRole('link', { name: /back to play/i }).click()
+  await page.getByRole('button', { name: 'Aloita' }).click()
+  await expect(page.getByRole('button', { name: 'Replay' })).toBeVisible()
+
+  await page.getByRole('link', { name: 'Models' }).click()
+  await expect(page.getByRole('heading', { name: /models/i })).toBeVisible()
+  await expect(page.getByRole('heading', { name: /model manager/i })).toBeVisible()
+})

--- a/tests/e2e/start-modal-flow.spec.ts
+++ b/tests/e2e/start-modal-flow.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from './guardedTest'
+
+test('start modal gates first sentence and allows immediate typing after Aloita', async ({ page }) => {
+  await page.goto('/play')
+
+  await expect(page.getByText('Oletko valmis ensimmäiseen lauseeseen?')).toBeVisible()
+  await page.getByRole('button', { name: 'Aloita' }).click()
+  await expect(page.getByText('Oletko valmis ensimmäiseen lauseeseen?')).toBeHidden()
+
+  const composer = page.getByLabel('Sentence answer input')
+  await composer.pressSequentially('olipakerran')
+  await composer.press('Enter')
+
+  await expect(page.getByText(/Stars:/)).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeDisabled()
+  await expect(page.getByRole('button', { name: 'Skip sentence' })).toBeDisabled()
+})

--- a/tests/e2e/story-flow.spec.ts
+++ b/tests/e2e/story-flow.spec.ts
@@ -3,10 +3,12 @@ import { expect, test } from './guardedTest'
 test('desktop story round supports replay, retry, and scoring', async ({ page }) => {
   await page.goto('/')
 
+  await page.getByRole('button', { name: 'Aloita' }).click()
   await page.getByRole('button', { name: 'Replay' }).click()
-  await page.getByLabel('Word 1').fill('Olipa')
-  await page.getByLabel('Word 2').fill('kerran')
-  await page.getByRole('button', { name: 'Submit' }).click()
+  const composer = page.getByLabel('Sentence answer input')
+  await composer.focus()
+  await composer.pressSequentially('olipakerran')
+  await composer.press('Enter')
 
   await expect(page.getByText(/Stars:/)).toBeVisible()
 })

--- a/tests/unit/app-replay-audio.test.tsx
+++ b/tests/unit/app-replay-audio.test.tsx
@@ -25,16 +25,24 @@ describe('App replay audio', () => {
     })
   })
 
-  it('requests audio on initial load and when replay is clicked', async () => {
+  it('starts playback from Aloita and replays when replay is clicked', async () => {
     const user = userEvent.setup()
     render(<App />)
+
+    expect(playSentenceAudio).toHaveBeenCalledTimes(0)
+
+    await user.click(screen.getByRole('button', { name: /aloita/i }))
 
     await waitFor(() => {
       expect(playSentenceAudio).toHaveBeenCalledTimes(1)
     })
 
+    const composer = screen.getByLabelText('Sentence answer input')
+    expect(composer).toHaveFocus()
+
     await user.click(screen.getByRole('button', { name: /replay/i }))
 
     expect(playSentenceAudio).toHaveBeenCalledTimes(2)
+    expect(composer).toHaveFocus()
   })
 })

--- a/tests/unit/app-routes.test.tsx
+++ b/tests/unit/app-routes.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { AppRoutes } from '../../src/routes/AppRoutes'
+
+describe('App routes', () => {
+  it('renders stories route heading', () => {
+    render(
+      <MemoryRouter initialEntries={['/stories']}>
+        <AppRoutes />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: /stories/i })).toBeInTheDocument()
+  })
+})

--- a/tests/unit/masked-input-model.test.ts
+++ b/tests/unit/masked-input-model.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildMaskModel,
+  extractWordsFromSlots,
+  getNextFillableIndex,
+  getPreviousFillableIndex,
+  isFillableLetter
+} from '../../src/play/maskedInputModel'
+
+describe('masked input model', () => {
+  it('marks letters as fillable and punctuation as static', () => {
+    const model = buildMaskModel('Olipa kerran.')
+    expect(model.fillableCount).toBe(11)
+    expect(model.tokens.at(-1)?.kind).toBe('static')
+    expect(model.tokens.at(-1)?.value).toBe('.')
+  })
+
+  it('supports finnish letters as fillable', () => {
+    expect(isFillableLetter('ä')).toBe(true)
+    expect(isFillableLetter('ö')).toBe(true)
+    expect(isFillableLetter('Å')).toBe(true)
+    expect(isFillableLetter(' ')).toBe(false)
+    expect(isFillableLetter('.')).toBe(false)
+  })
+
+  it('extracts words from slot values using sentence spacing', () => {
+    const model = buildMaskModel('Olipa kerran.')
+    const slots = 'olipakerran'.split('')
+    expect(extractWordsFromSlots(model, slots)).toEqual(['olipa', 'kerran'])
+  })
+
+  it('can move cursor left and right over fillable slots only', () => {
+    const model = buildMaskModel('Olipa kerran.')
+    expect(getNextFillableIndex(model, 0)).toBe(1)
+    expect(getPreviousFillableIndex(model, 6)).toBe(5)
+    expect(getPreviousFillableIndex(model, 0)).toBe(0)
+    expect(getNextFillableIndex(model, 10)).toBe(10)
+  })
+})

--- a/tests/unit/masked-sentence-composer.test.tsx
+++ b/tests/unit/masked-sentence-composer.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { MaskedSentenceComposer } from '../../src/components/MaskedSentenceComposer'
+
+describe('MaskedSentenceComposer', () => {
+  it('fills slots by continuous typing and ignores spaces', async () => {
+    const user = userEvent.setup()
+    render(<MaskedSentenceComposer sentence="Olipa kerran" onSubmit={vi.fn()} />)
+
+    await user.click(screen.getByLabelText('Sentence answer input'))
+    await user.keyboard('olipa kerran')
+
+    expect(screen.getByTestId('mask-value')).toHaveTextContent('olipakerran')
+  })
+
+  it('backspace deletes current slot and moves cursor left', async () => {
+    const user = userEvent.setup()
+    render(<MaskedSentenceComposer sentence="Olipa kerran" onSubmit={vi.fn()} />)
+
+    await user.click(screen.getByLabelText('Sentence answer input'))
+    await user.keyboard('olipakerran')
+    await user.keyboard('{Backspace}')
+
+    expect(screen.getByTestId('mask-value')).toHaveTextContent('olipakerra')
+    expect(screen.getByTestId('mask-cursor')).toHaveTextContent('9')
+  })
+
+  it('does not submit on Enter when sentence is incomplete and cursor stays put', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    render(<MaskedSentenceComposer sentence="Olipa kerran" onSubmit={onSubmit} />)
+
+    await user.click(screen.getByLabelText('Sentence answer input'))
+    await user.keyboard('olipa')
+    expect(screen.getByTestId('mask-cursor')).toHaveTextContent('5')
+
+    await user.keyboard('{Enter}')
+
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.getByTestId('mask-cursor')).toHaveTextContent('5')
+  })
+
+  it('submits on Enter when all fillable slots are filled', async () => {
+    const user = userEvent.setup()
+    const onSubmit = vi.fn()
+    render(<MaskedSentenceComposer sentence="Olipa kerran" onSubmit={onSubmit} />)
+
+    await user.click(screen.getByLabelText('Sentence answer input'))
+    await user.keyboard('olipakerran{Enter}')
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith('olipa kerran')
+  })
+})

--- a/tests/unit/models-page.test.tsx
+++ b/tests/unit/models-page.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { AppRoutes } from '../../src/routes/AppRoutes'
+
+describe('Models page', () => {
+  it('shows model manager only on /models', () => {
+    const modelsView = render(
+      <MemoryRouter initialEntries={['/models']}>
+        <AppRoutes />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: /models/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /model manager/i })).toBeInTheDocument()
+
+    modelsView.unmount()
+
+    render(
+      <MemoryRouter initialEntries={['/play']}>
+        <AppRoutes />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByRole('heading', { name: /model manager/i })).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/play-page-flow.test.tsx
+++ b/tests/unit/play-page-flow.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import App from '../../src/App'
+
+vi.mock('../../src/tts/playback', () => ({
+  playSentenceAudio: vi.fn().mockResolvedValue(undefined)
+}))
+
+describe('Play page flow', () => {
+  it('accepts continuous typing and scores a correct sentence', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.click(screen.getByRole('button', { name: /aloita/i }))
+    await user.click(screen.getByLabelText('Sentence answer input'))
+    await user.keyboard('olipakerran')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    expect(screen.getByText('Stars: 3')).toBeInTheDocument()
+  })
+
+  it('highlights invalid words and allows editing from clicked invalid word', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.click(screen.getByRole('button', { name: /aloita/i }))
+    await user.click(screen.getByLabelText('Sentence answer input'))
+    await user.keyboard('olipakarran')
+    await user.click(screen.getByRole('button', { name: /submit/i }))
+
+    const invalidSlot = screen.getByTestId('slot-5')
+    expect(invalidSlot).toHaveClass('invalid')
+
+    await user.click(invalidSlot)
+    expect(screen.getByTestId('mask-cursor')).toHaveTextContent('5')
+  })
+})

--- a/tests/unit/play-page-success-transition.test.tsx
+++ b/tests/unit/play-page-success-transition.test.tsx
@@ -1,0 +1,47 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import App from '../../src/App'
+
+vi.mock('../../src/tts/playback', () => ({
+  playSentenceAudio: vi.fn().mockResolvedValue(undefined)
+}))
+
+describe('Play page success transition', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('submits on Enter, disables controls, and auto-advances after transition delay', async () => {
+    vi.useFakeTimers()
+    render(<App />)
+
+    fireEvent.click(screen.getByRole('button', { name: /aloita/i }))
+
+    const progress = screen.getByText(/Starter Pack:/)
+    expect(progress).toHaveTextContent('Starter Pack: 1/50')
+
+    const composer = screen.getByLabelText('Sentence answer input')
+    composer.focus()
+    for (const key of 'olipakerran') {
+      fireEvent.keyDown(composer, { key })
+    }
+    fireEvent.keyDown(composer, { key: 'Enter' })
+
+    expect(screen.getByText('Stars: 3')).toBeInTheDocument()
+    expect(progress).toHaveTextContent('Starter Pack: 1/50')
+    expect(screen.getByRole('button', { name: /submit/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /skip sentence/i })).toBeDisabled()
+
+    await act(async () => {
+      vi.advanceTimersByTime(699)
+    })
+
+    expect(progress).toHaveTextContent('Starter Pack: 1/50')
+
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+    })
+
+    expect(progress).toHaveTextContent('Starter Pack: 2/50')
+  })
+})

--- a/tests/unit/play-transition-controls.test.tsx
+++ b/tests/unit/play-transition-controls.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import App from '../../src/App'
+
+vi.mock('../../src/tts/playback', () => ({
+  playSentenceAudio: vi.fn().mockResolvedValue(undefined)
+}))
+
+describe('Play transition controls', () => {
+  it('keeps submit disabled when sentence is not complete', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    await user.click(screen.getByRole('button', { name: 'Aloita' }))
+
+    const submit = screen.getByRole('button', { name: /submit/i })
+    expect(submit).toBeDisabled()
+
+    await user.click(screen.getByLabelText('Sentence answer input'))
+    await user.keyboard('olipa')
+    expect(submit).toBeDisabled()
+  })
+
+  it('renders submit and skip controls on the same row container', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<App />)
+    await user.click(screen.getByRole('button', { name: 'Aloita' }))
+
+    const actionRow = container.querySelector('.round-actions')
+    expect(actionRow).not.toBeNull()
+    expect(screen.getByRole('button', { name: /submit/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /skip sentence/i })).toBeInTheDocument()
+  })
+
+  it('does not render replay count in the visible UI', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+    await user.click(screen.getByRole('button', { name: 'Aloita' }))
+
+    expect(screen.queryByText(/replay count/i)).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/routes-view-separation.test.tsx
+++ b/tests/unit/routes-view-separation.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { AppRoutes } from '../../src/routes/AppRoutes'
+
+describe('Route view separation', () => {
+  it('keeps play route focused on gameplay only', () => {
+    render(
+      <MemoryRouter initialEntries={['/play']}>
+        <AppRoutes />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('button', { name: /replay/i })).toBeInTheDocument()
+    expect(screen.queryByLabelText(/import file/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /model manager/i })).not.toBeInTheDocument()
+  })
+
+  it('shows story import controls on stories route', () => {
+    render(
+      <MemoryRouter initialEntries={['/stories']}>
+        <AppRoutes />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: /stories/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/import file/i)).toBeInTheDocument()
+  })
+
+  it('shows model management on models route', () => {
+    render(
+      <MemoryRouter initialEntries={['/models']}>
+        <AppRoutes />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: /models/i })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: /model manager/i })).toBeInTheDocument()
+  })
+})

--- a/tests/unit/start-modal.test.tsx
+++ b/tests/unit/start-modal.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import App from '../../src/App'
+import { playSentenceAudio } from '../../src/tts/playback'
+
+vi.mock('../../src/tts/playback', () => ({
+  playSentenceAudio: vi.fn().mockResolvedValue(undefined)
+}))
+
+describe('Start modal', () => {
+  it('shows full-screen start gate and closes when Aloita is clicked', async () => {
+    const user = userEvent.setup()
+    render(<App />)
+
+    expect(screen.getByText('Oletko valmis ensimmäiseen lauseeseen?')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Aloita' })).toBeInTheDocument()
+    expect(playSentenceAudio).toHaveBeenCalledTimes(0)
+
+    await user.click(screen.getByRole('button', { name: 'Aloita' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Oletko valmis ensimmäiseen lauseeseen?')).not.toBeInTheDocument()
+    })
+    expect(playSentenceAudio).toHaveBeenCalledTimes(1)
+    expect(screen.getByLabelText('Sentence answer input')).toHaveFocus()
+  })
+})

--- a/tests/unit/stories-page.test.tsx
+++ b/tests/unit/stories-page.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { AppRoutes } from '../../src/routes/AppRoutes'
+
+describe('Stories page', () => {
+  it('shows story management controls on /stories and not on /play', () => {
+    const storiesView = render(
+      <MemoryRouter initialEntries={['/stories']}>
+        <AppRoutes />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByRole('heading', { name: /stories/i })).toBeInTheDocument()
+    expect(screen.getByLabelText(/import file/i)).toBeInTheDocument()
+
+    storiesView.unmount()
+
+    render(
+      <MemoryRouter initialEntries={['/play']}>
+        <AppRoutes />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByLabelText(/import file/i)).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add fullscreen start modal (Aloita) to gate first playback
- remove visible replay count and focus answer input on start/replay/new sentence
- enforce submit/skip disable rules during 700ms success transition and auto-advance
- add masked sentence composer with underscore slots and keyboard flow
- split app into routed views (`/play`, `/stories`, `/models`) and keep responsive styling
- update AGENTS.md with branch/PR/rebase workflow and OAuth-only Linear auth guidance

## Testing
- npm run ci

## Linear
- KUU-19 (implemented)
- KUU-20 (future scoring follow-up)
