### PR TITLE
feat: publish Kuupeli to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,42 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: deploy-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build app for GitHub Pages
+        run: npm run build
+        env:
+          VITE_BASE_PATH: /kuupeli/
+
+      - name: Deploy dist to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist
+          force_orphan: true

--- a/README.md
+++ b/README.md
@@ -27,3 +27,15 @@ npm run test:e2e
 npm run build
 npm run preview
 ```
+
+## Deployment (GitHub Pages)
+
+- Automatic deploy runs via `.github/workflows/deploy-pages.yml` on every push to `main`.
+- The workflow builds with `VITE_BASE_PATH=/kuupeli/` and publishes `dist/` to the `gh-pages` branch.
+- GitHub Pages should be configured to serve from the `gh-pages` branch (root folder).
+
+### Post-Deploy Check
+
+1. Open the published app URL: `https://elhigu.github.io/kuupeli/`.
+2. Confirm app shell loads with no missing asset errors in browser console.
+3. Confirm route navigation (`Play`, `Stories`, `Models`) and audio replay still work.

--- a/docs/plans/2026-03-01-kuupeli-v1-implementation-plan.md
+++ b/docs/plans/2026-03-01-kuupeli-v1-implementation-plan.md
@@ -736,3 +736,77 @@ Expected: PASS.
 git add package.json .github/workflows/ci.yml tests/unit/ci-script.test.ts
 git commit -m "chore: enforce ci verification gate for unit and e2e tests"
 ```
+
+### Task 17: GitHub Pages Deployment
+
+**Linear:** `KUU-22`
+
+**Files:**
+- Modify: `vite.config.ts`
+- Create: `.github/workflows/deploy-pages.yml`
+- Modify: `README.md`
+- Create: `tests/unit/github-pages-deploy.test.ts`
+
+**Step 1: Write the failing test**
+
+```ts
+import fs from 'node:fs'
+
+it('defines gh-pages deployment workflow for dist publishing', () => {
+  const workflow = fs.readFileSync('.github/workflows/deploy-pages.yml', 'utf8')
+  expect(workflow).toMatch(/push:/)
+  expect(workflow).toMatch(/branches:\\s*\\n\\s*- main/)
+  expect(workflow).toMatch(/github-pages-deploy-action/)
+  expect(workflow).toMatch(/branch: gh-pages/)
+})
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:unit -- tests/unit/github-pages-deploy.test.ts`
+Expected: FAIL until merge-to-main deployment workflow is configured.
+
+**Step 3: Write minimal implementation**
+
+```ts
+// vite.config.ts
+// Configure GitHub Pages project base path (for example, '/kuupeli/').
+```
+
+```yaml
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [main]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npm ci
+      - run: npm run build
+      - uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: dist
+```
+
+```md
+## GitHub Pages Deployment
+- Every merge/push to `main` triggers an automated deploy workflow.
+- The workflow builds the app and pushes `dist/` contents to `gh-pages`.
+- Open the Pages URL and verify static assets + app shell load correctly.
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:unit -- tests/unit/github-pages-deploy.test.ts`
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add vite.config.ts .github/workflows/deploy-pages.yml README.md tests/unit/github-pages-deploy.test.ts
+git commit -m "feat: auto-deploy gh-pages branch after merges to main"
+```

--- a/tests/unit/deploy-workflow.test.ts
+++ b/tests/unit/deploy-workflow.test.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('GitHub Pages deploy workflow', () => {
+  it('publishes dist to gh-pages on main', () => {
+    const workflow = fs.readFileSync('.github/workflows/deploy-pages.yml', 'utf8')
+    expect(workflow).toMatch(/push:\n\s+branches:\s*\["main"\]/)
+    expect(workflow).toMatch(/npm run build/)
+    expect(workflow).toMatch(/publish_branch:\s+gh-pages/)
+    expect(workflow).toMatch(/publish_dir:\s+\.\/dist/)
+  })
+})

--- a/tests/unit/vite-pages-base.test.ts
+++ b/tests/unit/vite-pages-base.test.ts
@@ -1,0 +1,12 @@
+import fs from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+describe('Vite pages base configuration', () => {
+  it('supports configurable base path for production deploys', () => {
+    const config = fs.readFileSync('vite.config.ts', 'utf8')
+    expect(config).toMatch(/process\.env\.VITE_BASE_PATH/)
+    expect(config).toMatch(/base:\s+basePath/)
+    expect(config).toMatch(/start_url:\s+basePath/)
+    expect(config).toMatch(/scope:\s+basePath/)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,43 +2,58 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 
-export default defineConfig({
-  plugins: [
-    react(),
-    VitePWA({
-      registerType: 'autoUpdate',
-      includeAssets: ['icons/icon-192.png', 'icons/icon-512.png'],
-      workbox: {
-        maximumFileSizeToCacheInBytes: 25 * 1024 * 1024
-      },
-      manifest: {
-        name: 'Kuupeli',
-        short_name: 'Kuupeli',
-        description: 'Gamified Finnish dictation learning app',
-        display: 'standalone',
-        start_url: '/',
-        scope: '/',
-        theme_color: '#0b2e4f',
-        background_color: '#f8f6f1',
-        icons: [
-          {
-            src: '/icons/icon-192.png',
-            sizes: '192x192',
-            type: 'image/png'
-          },
-          {
-            src: '/icons/icon-512.png',
-            sizes: '512x512',
-            type: 'image/png'
-          }
-        ]
-      }
-    })
-  ],
-  test: {
-    environment: 'jsdom',
-    setupFiles: ['./tests/setup.ts'],
-    include: ['tests/unit/**/*.test.ts', 'tests/unit/**/*.test.tsx'],
-    exclude: ['tests/e2e/**']
+function normalizeBasePath(rawPath: string): string {
+  const trimmed = rawPath.trim()
+  if (trimmed.length === 0) {
+    return '/'
+  }
+
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  return withLeadingSlash.endsWith('/') ? withLeadingSlash : `${withLeadingSlash}/`
+}
+
+export default defineConfig(() => {
+  const basePath = normalizeBasePath(process.env.VITE_BASE_PATH ?? '/')
+
+  return {
+    base: basePath,
+    plugins: [
+      react(),
+      VitePWA({
+        registerType: 'autoUpdate',
+        includeAssets: ['icons/icon-192.png', 'icons/icon-512.png'],
+        workbox: {
+          maximumFileSizeToCacheInBytes: 25 * 1024 * 1024
+        },
+        manifest: {
+          name: 'Kuupeli',
+          short_name: 'Kuupeli',
+          description: 'Gamified Finnish dictation learning app',
+          display: 'standalone',
+          start_url: basePath,
+          scope: basePath,
+          theme_color: '#0b2e4f',
+          background_color: '#f8f6f1',
+          icons: [
+            {
+              src: `${basePath}icons/icon-192.png`,
+              sizes: '192x192',
+              type: 'image/png'
+            },
+            {
+              src: `${basePath}icons/icon-512.png`,
+              sizes: '512x512',
+              type: 'image/png'
+            }
+          ]
+        }
+      })
+    ],
+    test: {
+      environment: 'jsdom',
+      setupFiles: ['./tests/setup.ts'],
+      include: ['tests/unit/**/*.test.ts', 'tests/unit/**/*.test.tsx'],
+      exclude: ['tests/e2e/**']
+    }
   }
 })


### PR DESCRIPTION
## Summary
- add automated GitHub Actions deployment workflow for GitHub Pages
- configure Vite/PWA base path via `VITE_BASE_PATH` for repository-path hosting
- document deployment behavior and post-deploy checks in README
- add unit tests for deploy workflow and pages base configuration
- include current `docs/plans/2026-03-01-kuupeli-v1-implementation-plan.md` changes in this PR

## Testing
- npm run ci

Refs: KUU-22
