### PR TITLE
feat: harden offline storage and service worker handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { STARTER_SENTENCES } from './data/starterSentences'
 import { logError, logEvent } from './observability/devLogger'
 import { findInvalidWords } from './scoring/retryEvaluator'
 import { scoreStars } from './scoring/starScorer'
+import { storageRecoveryGuidance } from './storage/storageGuidance'
 import { playSentenceAudio } from './tts/playback'
 
 type ThemeMode = 'dark' | 'light'
@@ -54,6 +55,7 @@ export default function App() {
   const [invalidIndexes, setInvalidIndexes] = useState<number[]>([])
   const [activeWordIndex, setActiveWordIndex] = useState<number | null>(null)
   const [audioError, setAudioError] = useState<string | null>(null)
+  const [storageWarning, setStorageWarning] = useState<string | null>(null)
   const [isAdvancing, setIsAdvancing] = useState(false)
   const [isStartModalOpen, setIsStartModalOpen] = useState(true)
   const [hasSessionStarted, setHasSessionStarted] = useState(false)
@@ -76,10 +78,13 @@ export default function App() {
 
     try {
       localStorage.setItem(THEME_STORAGE_KEY, theme)
+      setStorageWarning(null)
       logEvent('theme', 'persisted', { storageKey: THEME_STORAGE_KEY, theme })
-    } catch {
-      // Ignore storage write issues so gameplay continues.
-      logEvent('theme', 'persist_failed', { storageKey: THEME_STORAGE_KEY, theme })
+    } catch (error) {
+      // Keep gameplay running with explicit recovery guidance.
+      const guidance = storageRecoveryGuidance(error)
+      setStorageWarning(guidance)
+      logError('theme', 'persist_failed', error, { storageKey: THEME_STORAGE_KEY, theme })
     }
   }, [theme])
 
@@ -337,6 +342,7 @@ export default function App() {
       <p aria-live="polite">
         Starter Pack: {sentenceIndex + 1}/{STARTER_SENTENCES.length}
       </p>
+      {storageWarning && <p role="alert">{storageWarning}</p>}
 
       <section className={`round-panel${isAdvancing ? ' round-panel-success' : ''}`}>
         <ReplayButton

--- a/src/components/ModelManagerPanel.tsx
+++ b/src/components/ModelManagerPanel.tsx
@@ -6,6 +6,7 @@ import { logError, logEvent } from '../observability/devLogger'
 export function ModelManagerPanel() {
   const [installed, setInstalled] = useState<string[]>([])
   const [activeModel, setActiveModelState] = useState<string>('')
+  const [storageError, setStorageError] = useState<string | null>(null)
 
   async function refresh() {
     try {
@@ -14,11 +15,13 @@ export function ModelManagerPanel() {
 
       setInstalled(models.map((model) => model.id))
       setActiveModelState(active)
+      setStorageError(null)
       logEvent('models', 'panel_refreshed', {
         installedModelIds: models.map((model) => model.id),
         activeModelId: active
       })
     } catch (error) {
+      setStorageError(error instanceof Error ? error.message : 'Model storage is unavailable.')
       logError('models', 'panel_refresh_failed', error)
     }
   }
@@ -34,6 +37,7 @@ export function ModelManagerPanel() {
         Models are local Kuupeli runtime profiles in this version. They do not download separate cloud or external
         AI model files yet.
       </p>
+      {storageError && <p role="alert">{storageError}</p>}
       <ul>
         {MODEL_CATALOG.map((model) => {
           const isInstalled = installed.includes(model.id)
@@ -51,6 +55,7 @@ export function ModelManagerPanel() {
                       await installModel(model.id)
                       await refresh()
                     } catch (error) {
+                      setStorageError(error instanceof Error ? error.message : 'Model storage is unavailable.')
                       logError('models', 'install_failed', error, { modelId: model.id })
                     }
                   }}
@@ -67,6 +72,7 @@ export function ModelManagerPanel() {
                         await setActiveModel(model.id)
                         await refresh()
                       } catch (error) {
+                        setStorageError(error instanceof Error ? error.message : 'Model storage is unavailable.')
                         logError('models', 'set_active_failed', error, { modelId: model.id })
                       }
                     }}
@@ -83,6 +89,7 @@ export function ModelManagerPanel() {
                           await removeModel(model.id)
                           await refresh()
                         } catch (error) {
+                          setStorageError(error instanceof Error ? error.message : 'Model storage is unavailable.')
                           logError('models', 'remove_failed', error, { modelId: model.id })
                         }
                       }}

--- a/src/db/repositories/progressRepo.ts
+++ b/src/db/repositories/progressRepo.ts
@@ -1,21 +1,32 @@
 import { getDb, type SessionProgress } from '../schema'
-import { logEvent } from '../../observability/devLogger'
+import { logError, logEvent } from '../../observability/devLogger'
+import { storageRecoveryGuidance } from '../../storage/storageGuidance'
 
 export async function saveProgress(progress: SessionProgress): Promise<void> {
-  const db = await getDb()
-  await db.put('progress', progress)
-  logEvent('db_progress', 'saved', {
-    packId: progress.packId,
-    sentenceIndex: progress.sentenceIndex
-  })
+  try {
+    const db = await getDb()
+    await db.put('progress', progress)
+    logEvent('db_progress', 'saved', {
+      packId: progress.packId,
+      sentenceIndex: progress.sentenceIndex
+    })
+  } catch (error) {
+    logError('db_progress', 'save_failed', error, { packId: progress.packId })
+    throw new Error(storageRecoveryGuidance(error))
+  }
 }
 
 export async function getProgress(packId: string): Promise<SessionProgress | undefined> {
-  const db = await getDb()
-  const progress = await db.get('progress', packId)
-  logEvent('db_progress', 'read', {
-    packId,
-    found: Boolean(progress)
-  })
-  return progress
+  try {
+    const db = await getDb()
+    const progress = await db.get('progress', packId)
+    logEvent('db_progress', 'read', {
+      packId,
+      found: Boolean(progress)
+    })
+    return progress
+  } catch (error) {
+    logError('db_progress', 'read_failed', error, { packId })
+    throw new Error(storageRecoveryGuidance(error))
+  }
 }

--- a/src/db/repositories/trainingPackRepo.ts
+++ b/src/db/repositories/trainingPackRepo.ts
@@ -1,21 +1,32 @@
 import { getDb, type TrainingPack } from '../schema'
-import { logEvent } from '../../observability/devLogger'
+import { logError, logEvent } from '../../observability/devLogger'
+import { storageRecoveryGuidance } from '../../storage/storageGuidance'
 
 export async function saveTrainingPack(pack: TrainingPack): Promise<void> {
-  const db = await getDb()
-  await db.put('trainingPacks', pack)
-  logEvent('db_training_pack', 'saved', {
-    packId: pack.id,
-    sentenceCount: pack.sentences.length
-  })
+  try {
+    const db = await getDb()
+    await db.put('trainingPacks', pack)
+    logEvent('db_training_pack', 'saved', {
+      packId: pack.id,
+      sentenceCount: pack.sentences.length
+    })
+  } catch (error) {
+    logError('db_training_pack', 'save_failed', error, { packId: pack.id })
+    throw new Error(storageRecoveryGuidance(error))
+  }
 }
 
 export async function getTrainingPack(id: string): Promise<TrainingPack | undefined> {
-  const db = await getDb()
-  const pack = await db.get('trainingPacks', id)
-  logEvent('db_training_pack', 'read', {
-    packId: id,
-    found: Boolean(pack)
-  })
-  return pack
+  try {
+    const db = await getDb()
+    const pack = await db.get('trainingPacks', id)
+    logEvent('db_training_pack', 'read', {
+      packId: id,
+      found: Boolean(pack)
+    })
+    return pack
+  } catch (error) {
+    logError('db_training_pack', 'read_failed', error, { packId: id })
+    throw new Error(storageRecoveryGuidance(error))
+  }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,7 +18,8 @@ logEvent('app_boot', 'starting_render')
 registerServiceWorker({
   isProduction: import.meta.env.PROD,
   serviceWorker: 'serviceWorker' in navigator ? navigator.serviceWorker : undefined,
-  addLoadListener: (listener) => window.addEventListener('load', listener)
+  addLoadListener: (listener) => window.addEventListener('load', listener),
+  baseUrl: import.meta.env.BASE_URL
 })
 
 createRoot(container).render(

--- a/src/models/modelManager.ts
+++ b/src/models/modelManager.ts
@@ -1,12 +1,31 @@
 import { MODEL_CATALOG, type ModelCatalogEntry } from './catalog'
-import { logEvent } from '../observability/devLogger'
+import { logError, logEvent } from '../observability/devLogger'
+import { storageRecoveryGuidance } from '../storage/storageGuidance'
 
 const STORAGE_KEY = 'kuupeli-installed-models'
 const ACTIVE_MODEL_KEY = 'kuupeli-active-model'
 const DEFAULT_MODEL = 'fi-starter-small'
 
+function readStorageItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key)
+  } catch (error) {
+    logError('models_store', 'storage_read_failed', error, { key })
+    throw new Error(storageRecoveryGuidance(error))
+  }
+}
+
+function writeStorageItem(key: string, value: string) {
+  try {
+    localStorage.setItem(key, value)
+  } catch (error) {
+    logError('models_store', 'storage_write_failed', error, { key })
+    throw new Error(storageRecoveryGuidance(error))
+  }
+}
+
 function readInstalledModelIds(): string[] {
-  const raw = localStorage.getItem(STORAGE_KEY)
+  const raw = readStorageItem(STORAGE_KEY)
 
   if (!raw) {
     return [DEFAULT_MODEL]
@@ -21,7 +40,7 @@ function readInstalledModelIds(): string[] {
 }
 
 function writeInstalledModelIds(ids: string[]) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(new Set(ids))))
+  writeStorageItem(STORAGE_KEY, JSON.stringify(Array.from(new Set(ids))))
 }
 
 export async function listModels(): Promise<ModelCatalogEntry[]> {
@@ -36,8 +55,8 @@ export async function installModel(modelId: string): Promise<void> {
   writeInstalledModelIds([...installed, modelId])
   logEvent('models_store', 'installed', { modelId })
 
-  if (!localStorage.getItem(ACTIVE_MODEL_KEY)) {
-    localStorage.setItem(ACTIVE_MODEL_KEY, modelId)
+  if (!readStorageItem(ACTIVE_MODEL_KEY)) {
+    writeStorageItem(ACTIVE_MODEL_KEY, modelId)
     logEvent('models_store', 'active_auto_set', { modelId })
   }
 }
@@ -47,8 +66,8 @@ export async function removeModel(modelId: string): Promise<void> {
   writeInstalledModelIds(installed.length > 0 ? installed : [DEFAULT_MODEL])
   logEvent('models_store', 'removed', { modelId })
 
-  if (localStorage.getItem(ACTIVE_MODEL_KEY) === modelId) {
-    localStorage.setItem(ACTIVE_MODEL_KEY, DEFAULT_MODEL)
+  if (readStorageItem(ACTIVE_MODEL_KEY) === modelId) {
+    writeStorageItem(ACTIVE_MODEL_KEY, DEFAULT_MODEL)
     logEvent('models_store', 'active_reset_to_default', { modelId: DEFAULT_MODEL })
   }
 }
@@ -60,12 +79,12 @@ export async function setActiveModel(modelId: string): Promise<void> {
     throw new Error(`Model not installed: ${modelId}`)
   }
 
-  localStorage.setItem(ACTIVE_MODEL_KEY, modelId)
+  writeStorageItem(ACTIVE_MODEL_KEY, modelId)
   logEvent('models_store', 'active_set', { modelId })
 }
 
 export async function getActiveModel(): Promise<string> {
-  const active = localStorage.getItem(ACTIVE_MODEL_KEY)
+  const active = readStorageItem(ACTIVE_MODEL_KEY)
   const activeModel = active ?? DEFAULT_MODEL
   logEvent('models_store', 'active_read', { modelId: activeModel })
   return activeModel

--- a/src/offline/cachePolicy.ts
+++ b/src/offline/cachePolicy.ts
@@ -1,7 +1,19 @@
+function normalizePath(path: string): string {
+  const noFragment = path.split('#', 1)[0] ?? ''
+  const noQuery = noFragment.split('?', 1)[0] ?? ''
+  return noQuery || '/'
+}
+
 export function shouldServeFromCache(path: string): boolean {
-  if (path === '/' || path === '/index.html') {
+  const normalizedPath = normalizePath(path)
+
+  if (normalizedPath === '/' || normalizedPath.endsWith('/index.html')) {
     return true
   }
 
-  return path.startsWith('/assets/') || path.startsWith('/icons/')
+  if (/(^|\/)(play|stories|models)$/.test(normalizedPath)) {
+    return true
+  }
+
+  return normalizedPath.includes('/assets/') || normalizedPath.includes('/icons/') || normalizedPath.endsWith('/manifest.webmanifest')
 }

--- a/src/pwa/registerServiceWorker.ts
+++ b/src/pwa/registerServiceWorker.ts
@@ -1,4 +1,4 @@
-import { logEvent } from '../observability/devLogger'
+import { logError, logEvent } from '../observability/devLogger'
 
 export interface ServiceWorkerRegisterTarget {
   register: (scriptUrl: string) => Promise<unknown>
@@ -8,6 +8,20 @@ export interface RegisterServiceWorkerOptions {
   isProduction: boolean
   serviceWorker?: ServiceWorkerRegisterTarget
   addLoadListener: (listener: () => void) => void
+  baseUrl?: string
+}
+
+function normalizeBaseUrl(rawBaseUrl: string): string {
+  if (!rawBaseUrl) {
+    return '/'
+  }
+
+  return rawBaseUrl.endsWith('/') ? rawBaseUrl : `${rawBaseUrl}/`
+}
+
+function serviceWorkerScriptFor(baseUrl?: string): string {
+  const normalizedBase = normalizeBaseUrl(baseUrl ?? '/')
+  return `${normalizedBase}sw.js`
 }
 
 export function registerServiceWorker(options: RegisterServiceWorkerOptions): boolean {
@@ -20,8 +34,16 @@ export function registerServiceWorker(options: RegisterServiceWorkerOptions): bo
   }
 
   options.addLoadListener(() => {
-    logEvent('pwa', 'service_worker_registering', { script: '/sw.js' })
-    void options.serviceWorker?.register('/sw.js')
+    const scriptUrl = serviceWorkerScriptFor(options.baseUrl)
+    logEvent('pwa', 'service_worker_registering', { script: scriptUrl })
+    void options.serviceWorker
+      ?.register(scriptUrl)
+      .then(() => {
+        logEvent('pwa', 'service_worker_registered', { script: scriptUrl })
+      })
+      .catch((error) => {
+        logError('pwa', 'service_worker_registration_failed', error, { script: scriptUrl })
+      })
   })
 
   logEvent('pwa', 'service_worker_listener_attached')

--- a/src/storage/storageGuidance.ts
+++ b/src/storage/storageGuidance.ts
@@ -1,0 +1,50 @@
+const QUOTA_ERROR_NAMES = new Set(['QuotaExceededError', 'NS_ERROR_DOM_QUOTA_REACHED'])
+const UNAVAILABLE_ERROR_NAMES = new Set(['SecurityError', 'InvalidStateError'])
+
+function asErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (typeof error === 'string') {
+    return error
+  }
+
+  return 'Unknown storage error'
+}
+
+export function classifyStorageError(error: unknown): 'quota' | 'unavailable' | 'unknown' {
+  if (error instanceof DOMException && QUOTA_ERROR_NAMES.has(error.name)) {
+    return 'quota'
+  }
+
+  if (error instanceof DOMException && UNAVAILABLE_ERROR_NAMES.has(error.name)) {
+    return 'unavailable'
+  }
+
+  const normalizedMessage = asErrorMessage(error).toLowerCase()
+
+  if (normalizedMessage.includes('quota')) {
+    return 'quota'
+  }
+
+  if (normalizedMessage.includes('storage') && normalizedMessage.includes('disabled')) {
+    return 'unavailable'
+  }
+
+  return 'unknown'
+}
+
+export function storageRecoveryGuidance(error: unknown): string {
+  const kind = classifyStorageError(error)
+
+  if (kind === 'quota') {
+    return 'Browser storage is full. Free some storage or remove old Kuupeli data and try again.'
+  }
+
+  if (kind === 'unavailable') {
+    return 'Browser storage is unavailable. Disable strict private mode or storage blocking, then retry.'
+  }
+
+  return 'Local storage operation failed. Reload and try again.'
+}

--- a/tests/unit/offline-hardening.test.ts
+++ b/tests/unit/offline-hardening.test.ts
@@ -6,4 +6,9 @@ describe('Cache policy', () => {
     expect(shouldServeFromCache('/assets/main.js')).toBe(true)
     expect(shouldServeFromCache('/api/something')).toBe(false)
   })
+
+  it('normalizes query/hash paths before cache decision', () => {
+    expect(shouldServeFromCache('/assets/main.js?v=1#chunk')).toBe(true)
+    expect(shouldServeFromCache('/play?from=home')).toBe(true)
+  })
 })

--- a/tests/unit/service-worker-registration.test.ts
+++ b/tests/unit/service-worker-registration.test.ts
@@ -37,4 +37,23 @@ describe('Service worker registration', () => {
     expect(addLoadListener).toHaveBeenCalledTimes(1)
     expect(register).toHaveBeenCalledWith('/sw.js')
   })
+
+  it('registers service worker under configured base path', async () => {
+    const register = vi.fn().mockResolvedValue(undefined)
+    const addLoadListener = vi.fn<(listener: () => void) => void>()
+
+    addLoadListener.mockImplementation((listener) => {
+      listener()
+    })
+
+    registerServiceWorker({
+      isProduction: true,
+      serviceWorker: { register },
+      addLoadListener,
+      baseUrl: '/kuupeli/'
+    })
+
+    await Promise.resolve()
+    expect(register).toHaveBeenCalledWith('/kuupeli/sw.js')
+  })
 })

--- a/tests/unit/theme-mode.test.tsx
+++ b/tests/unit/theme-mode.test.tsx
@@ -1,9 +1,13 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import App from '../../src/App'
 
 describe('Theme mode', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   beforeEach(() => {
     localStorage.clear()
     delete document.documentElement.dataset.theme
@@ -27,5 +31,15 @@ describe('Theme mode', () => {
       expect(document.documentElement.dataset.theme).toBe('light')
       expect(localStorage.getItem('kuupeli-theme')).toBe('light')
     })
+  })
+
+  it('shows recoverable guidance when browser storage is full', async () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('Storage full', 'QuotaExceededError')
+    })
+
+    render(<App />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/browser storage is full/i)
   })
 })

--- a/tests/unit/widgets/model-manager-panel.test.tsx
+++ b/tests/unit/widgets/model-manager-panel.test.tsx
@@ -1,8 +1,12 @@
 import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ModelManagerPanel } from '../../../src/components/ModelManagerPanel'
 
 describe('ModelManagerPanel', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('renders catalog entries and manager heading', async () => {
     render(<ModelManagerPanel />)
 
@@ -11,5 +15,15 @@ describe('ModelManagerPanel', () => {
       screen.getByText(/models are local kuupeli runtime profiles in this version/i)
     ).toBeInTheDocument()
     expect(await screen.findByText(/finnish starter small/i)).toBeInTheDocument()
+  })
+
+  it('shows recoverable guidance when storage read fails', async () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new DOMException('Storage full', 'QuotaExceededError')
+    })
+
+    render(<ModelManagerPanel />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/browser storage is full/i)
   })
 })


### PR DESCRIPTION
## Summary
- make service worker registration base-path aware and add failure/success diagnostics
- normalize cache policy path matching for route/query/hash determinism
- add shared storage error classification and recoverable user guidance messages
- surface storage failures in gameplay theme persistence and model manager UI
- harden db/model storage operations with structured error handling

## Testing
- npm run ci

Refs: KUU-15