### PR TITLE
feat: prefetch next sentence audio and cache clips

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { logError, logEvent } from './observability/devLogger'
 import { findInvalidWords } from './scoring/retryEvaluator'
 import { scoreStars } from './scoring/starScorer'
 import { storageRecoveryGuidance } from './storage/storageGuidance'
+import { prefetchSentenceClip } from './tts/audioPrefetchQueue'
 import { playSentenceAudio } from './tts/playback'
 
 type ThemeMode = 'dark' | 'light'
@@ -224,6 +225,47 @@ export default function App() {
       })
     })
   }, [activeStory.id, hasSessionStarted, sentenceCount, sentenceIndex])
+
+  useEffect(() => {
+    if (!hasSessionStarted) {
+      return
+    }
+
+    const nextSentence = currentSentences[sentenceIndex + 1]
+    if (!nextSentence) {
+      return
+    }
+
+    let cancelled = false
+
+    const prefetchNextSentence = async () => {
+      try {
+        const clip = await prefetchSentenceClip(nextSentence)
+        if (!cancelled) {
+          logEvent('audio_prefetch', 'next_sentence_prefetched', {
+            storyId: activeStory.id,
+            fromSentenceIndex: sentenceIndex,
+            targetSentenceIndex: sentenceIndex + 1,
+            clipBytes: clip.byteLength
+          })
+        }
+      } catch (error) {
+        if (!cancelled) {
+          logError('audio_prefetch', 'next_sentence_prefetch_failed', error, {
+            storyId: activeStory.id,
+            fromSentenceIndex: sentenceIndex,
+            targetSentenceIndex: sentenceIndex + 1
+          })
+        }
+      }
+    }
+
+    void prefetchNextSentence()
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeStory.id, currentSentences, hasSessionStarted, sentenceIndex])
 
   useEffect(() => {
     if (!isAdvancing) {

--- a/src/tts/audioPrefetchQueue.ts
+++ b/src/tts/audioPrefetchQueue.ts
@@ -1,32 +1,56 @@
+import { logEvent } from '../observability/devLogger'
 import { ClipCache } from './clipCache'
 import { synthesizeSentence } from './ttsRuntime'
-import { logEvent } from '../observability/devLogger'
+
+function cacheKey(sentence: string, voice: string): string {
+  return `${voice}::${sentence}`
+}
 
 export class AudioPrefetchQueue {
   private readonly cache = new ClipCache()
 
-  async prefetch(sentence: string): Promise<ArrayBuffer> {
-    const existing = this.cache.get(sentence)
+  async prefetch(sentence: string, voice = 'fi'): Promise<ArrayBuffer> {
+    const key = cacheKey(sentence, voice)
+    const existing = this.cache.get(key)
     if (existing) {
-      logEvent('audio_prefetch', 'cache_hit', { sentenceLength: sentence.length })
+      logEvent('audio_prefetch', 'cache_hit', { sentenceLength: sentence.length, voice })
       return existing
     }
 
-    logEvent('audio_prefetch', 'cache_miss_generate', { sentenceLength: sentence.length })
-    const generated = await synthesizeSentence(sentence)
-    this.cache.set(sentence, generated)
+    logEvent('audio_prefetch', 'cache_miss_generate', { sentenceLength: sentence.length, voice })
+    const generated = await synthesizeSentence(sentence, { voice })
+    this.cache.set(key, generated)
     logEvent('audio_prefetch', 'generated_and_cached', {
       sentenceLength: sentence.length,
-      clipBytes: generated.byteLength
+      clipBytes: generated.byteLength,
+      voice
     })
     return generated
   }
 
-  has(sentence: string): boolean {
-    return this.cache.has(sentence)
+  has(sentence: string, voice = 'fi'): boolean {
+    return this.cache.has(cacheKey(sentence, voice))
   }
 
-  get(sentence: string): ArrayBuffer | undefined {
-    return this.cache.get(sentence)
+  get(sentence: string, voice = 'fi'): ArrayBuffer | undefined {
+    return this.cache.get(cacheKey(sentence, voice))
   }
+
+  clear() {
+    this.cache.clear()
+  }
+}
+
+const sharedAudioPrefetchQueue = new AudioPrefetchQueue()
+
+export async function prefetchSentenceClip(sentence: string, voice = 'fi'): Promise<ArrayBuffer> {
+  return sharedAudioPrefetchQueue.prefetch(sentence, voice)
+}
+
+export function getPrefetchedSentenceClip(sentence: string, voice = 'fi'): ArrayBuffer | undefined {
+  return sharedAudioPrefetchQueue.get(sentence, voice)
+}
+
+export function resetPrefetchQueueForTest() {
+  sharedAudioPrefetchQueue.clear()
 }

--- a/src/tts/clipCache.ts
+++ b/src/tts/clipCache.ts
@@ -2,13 +2,36 @@ import { logEvent } from '../observability/devLogger'
 
 export class ClipCache {
   private readonly cache = new Map<string, ArrayBuffer>()
+  private readonly maxEntries: number
+
+  constructor(maxEntries = 8) {
+    this.maxEntries = maxEntries
+  }
 
   set(sentence: string, clip: ArrayBuffer) {
+    if (this.cache.has(sentence)) {
+      this.cache.delete(sentence)
+    }
+
     this.cache.set(sentence, clip)
+
+    if (this.cache.size > this.maxEntries) {
+      const oldestSentence = this.cache.keys().next().value as string | undefined
+      if (oldestSentence) {
+        this.cache.delete(oldestSentence)
+        logEvent('clip_cache', 'evicted_oldest', {
+          sentenceLength: oldestSentence.length,
+          entryCount: this.cache.size,
+          maxEntries: this.maxEntries
+        })
+      }
+    }
+
     logEvent('clip_cache', 'set', {
       sentenceLength: sentence.length,
       clipBytes: clip.byteLength,
-      entryCount: this.cache.size
+      entryCount: this.cache.size,
+      maxEntries: this.maxEntries
     })
   }
 
@@ -28,5 +51,10 @@ export class ClipCache {
       hit
     })
     return hit
+  }
+
+  clear() {
+    this.cache.clear()
+    logEvent('clip_cache', 'cleared')
   }
 }

--- a/src/tts/playback.ts
+++ b/src/tts/playback.ts
@@ -1,5 +1,6 @@
 import { getActiveModel, getModelById, getModelVoiceType } from '../models/modelManager'
 import { logEvent } from '../observability/devLogger'
+import { getPrefetchedSentenceClip } from './audioPrefetchQueue'
 import { predictPiperVoice } from './piperWebRuntime'
 import { synthesizeSentence } from './ttsRuntime'
 
@@ -103,27 +104,52 @@ export async function playSentenceAudioWithModel(
 ): Promise<void> {
   const model = getModelById(override.modelId)
   const voiceTypeId = override.voiceTypeId ?? (await getModelVoiceType(override.modelId))
+  const selectedVoice =
+    model?.engine === 'espeak-ng'
+      ? (model.voiceTypes.find((option) => option.id === voiceTypeId) ?? model.voiceTypes[0])?.runtimeVoice ?? 'fi'
+      : undefined
 
   logEvent('audio_playback', 'start', {
     textLength: text.length,
     sentence: text,
     activeModelId: override.modelId,
     engine: model?.engine ?? 'unknown',
-    voiceTypeId
+    voiceTypeId,
+    voice: selectedVoice
   })
 
   try {
-    const wavBuffer = await synthesizeFromSelection(text, override.modelId, voiceTypeId)
-    logEvent('audio_playback', 'synthesized', {
-      bytes: wavBuffer.byteLength,
-      activeModelId: override.modelId,
-      engine: model?.engine ?? 'unknown'
-    })
-    logEvent('audio_playback', 'wasm_synthesized', {
-      bytes: wavBuffer.byteLength,
-      activeModelId: override.modelId,
-      engine: model?.engine ?? 'unknown'
-    })
+    const prefetched = selectedVoice ? getPrefetchedSentenceClip(text, selectedVoice) : undefined
+    const wavBuffer = prefetched ?? (await synthesizeFromSelection(text, override.modelId, voiceTypeId))
+
+    if (prefetched) {
+      logEvent('audio_playback', 'prefetch_cache_hit', {
+        textLength: text.length,
+        bytes: prefetched.byteLength,
+        activeModelId: override.modelId,
+        voice: selectedVoice
+      })
+    } else {
+      if (selectedVoice) {
+        logEvent('audio_playback', 'prefetch_cache_miss', {
+          textLength: text.length,
+          activeModelId: override.modelId,
+          voice: selectedVoice
+        })
+      }
+
+      logEvent('audio_playback', 'synthesized', {
+        bytes: wavBuffer.byteLength,
+        activeModelId: override.modelId,
+        engine: model?.engine ?? 'unknown'
+      })
+      logEvent('audio_playback', 'wasm_synthesized', {
+        bytes: wavBuffer.byteLength,
+        activeModelId: override.modelId,
+        engine: model?.engine ?? 'unknown'
+      })
+    }
+
     await playWavBuffer(wavBuffer)
     logEvent('audio_playback', 'playback_completed', {
       activeModelId: override.modelId

--- a/tests/unit/audio-prefetch.test.ts
+++ b/tests/unit/audio-prefetch.test.ts
@@ -1,10 +1,23 @@
-import { describe, expect, it } from 'vitest'
-import { AudioPrefetchQueue } from '../../src/tts/audioPrefetchQueue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/tts/ttsRuntime', () => ({
+  synthesizeSentence: vi.fn(async (text: string) => new TextEncoder().encode(text).buffer)
+}))
+
+import { getPrefetchedSentenceClip, prefetchSentenceClip, resetPrefetchQueueForTest } from '../../src/tts/audioPrefetchQueue'
+import { synthesizeSentence } from '../../src/tts/ttsRuntime'
 
 describe('Audio prefetch queue', () => {
-  it('prefetches next sentence clip', async () => {
-    const queue = new AudioPrefetchQueue()
-    await queue.prefetch('Sitten tuli ilta.')
-    expect(queue.has('Sitten tuli ilta.')).toBe(true)
+  beforeEach(() => {
+    resetPrefetchQueueForTest()
+    vi.clearAllMocks()
+  })
+
+  it('prefetches and reuses cached sentence clip', async () => {
+    await prefetchSentenceClip('Sitten tuli ilta.')
+    await prefetchSentenceClip('Sitten tuli ilta.')
+
+    expect(getPrefetchedSentenceClip('Sitten tuli ilta.')).toBeDefined()
+    expect(synthesizeSentence).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/unit/clip-cache.test.ts
+++ b/tests/unit/clip-cache.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { ClipCache } from '../../src/tts/clipCache'
+
+describe('ClipCache', () => {
+  it('evicts oldest clips when capacity is exceeded', () => {
+    const cache = new ClipCache(2)
+
+    cache.set('A', new Uint8Array([1]).buffer)
+    cache.set('B', new Uint8Array([2]).buffer)
+    cache.set('C', new Uint8Array([3]).buffer)
+
+    expect(cache.has('A')).toBe(false)
+    expect(cache.has('B')).toBe(true)
+    expect(cache.has('C')).toBe(true)
+  })
+})

--- a/tests/unit/playback-prefetch-cache.test.ts
+++ b/tests/unit/playback-prefetch-cache.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/tts/ttsRuntime', () => ({
+  synthesizeSentence: vi.fn(async (text: string) => new TextEncoder().encode(text).buffer)
+}))
+
+vi.mock('../../src/models/modelManager', () => ({
+  getActiveModel: vi.fn(async () => 'fi-starter-small'),
+  getModelById: vi.fn(() => ({
+    id: 'fi-starter-small',
+    engine: 'espeak-ng',
+    piperVoiceId: undefined,
+    voiceTypes: [
+      {
+        id: 'fi-default',
+        runtimeVoice: 'fi'
+      }
+    ]
+  })),
+  getModelVoiceType: vi.fn(async () => 'fi-default')
+}))
+
+import { prefetchSentenceClip, resetPrefetchQueueForTest } from '../../src/tts/audioPrefetchQueue'
+import { playSentenceAudio } from '../../src/tts/playback'
+import { synthesizeSentence } from '../../src/tts/ttsRuntime'
+
+class FakeAudio {
+  onended: (() => void) | null = null
+  onerror: (() => void) | null = null
+
+  constructor(_src: string) {}
+
+  play() {
+    queueMicrotask(() => this.onended?.())
+    return Promise.resolve()
+  }
+}
+
+describe('Playback prefetch cache', () => {
+  beforeEach(() => {
+    resetPrefetchQueueForTest()
+    vi.clearAllMocks()
+    vi.stubGlobal('Audio', FakeAudio)
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:kuupeli-test'),
+      revokeObjectURL: vi.fn()
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('plays prefetched clip without regenerating audio', async () => {
+    const sentence = 'Sitten tuli ilta.'
+
+    await prefetchSentenceClip(sentence)
+    await playSentenceAudio(sentence)
+
+    expect(synthesizeSentence).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary
- pre-generate next sentence audio after each sentence transition
- use shared prefetch queue between gameplay flow and playback path
- play prefetched clip directly when available to reduce perceived delay
- add bounded clip cache with eviction behavior to control memory growth
- add unit coverage for cache reuse and playback cache-hit behavior

## Testing
- npm run ci

Refs: KUU-13