### PR TITLE
feat: add training pack list/remove repository operations

### DIFF
--- a/src/db/repositories/trainingPackRepo.ts
+++ b/src/db/repositories/trainingPackRepo.ts
@@ -19,3 +19,25 @@ export async function getTrainingPack(id: string): Promise<TrainingPack | undefi
   })
   return pack
 }
+
+export async function listTrainingPacks(): Promise<TrainingPack[]> {
+  const db = await getDb()
+  const packs = await db.getAll('trainingPacks')
+  logEvent('db_training_pack', 'listed', {
+    count: packs.length
+  })
+  return packs
+}
+
+export async function removeTrainingPack(id: string): Promise<void> {
+  const db = await getDb()
+  const transaction = db.transaction(['trainingPacks', 'progress'], 'readwrite')
+  await transaction.objectStore('trainingPacks').delete(id)
+  await transaction.objectStore('progress').delete(id)
+  await transaction.done
+
+  logEvent('db_training_pack', 'removed', {
+    packId: id,
+    clearedProgress: true
+  })
+}

--- a/tests/unit/db-repositories.test.ts
+++ b/tests/unit/db-repositories.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { getTrainingPack, saveTrainingPack } from '../../src/db/repositories/trainingPackRepo'
+import { getProgress, saveProgress } from '../../src/db/repositories/progressRepo'
+import {
+  getTrainingPack,
+  listTrainingPacks,
+  removeTrainingPack,
+  saveTrainingPack
+} from '../../src/db/repositories/trainingPackRepo'
 
 describe('Training pack repository', () => {
   beforeEach(async () => {
@@ -11,5 +17,28 @@ describe('Training pack repository', () => {
     const pack = await getTrainingPack('pack-1')
     expect(pack?.title).toBe('Book')
     expect(pack?.sentences).toEqual(['Hei maailma.'])
+  })
+
+  it('lists saved training packs in key order', async () => {
+    await saveTrainingPack({ id: 'pack-2', title: 'Second', sentences: ['Kaksi.'] })
+    await saveTrainingPack({ id: 'pack-1', title: 'First', sentences: ['Yksi.'] })
+
+    const packs = await listTrainingPacks()
+
+    expect(packs.map((pack) => pack.id)).toEqual(['pack-1', 'pack-2'])
+  })
+
+  it('removes a training pack and clears its progress', async () => {
+    await saveTrainingPack({ id: 'pack-1', title: 'Book', sentences: ['Hei maailma.'] })
+    await saveProgress({
+      packId: 'pack-1',
+      sentenceIndex: 3,
+      updatedAt: new Date().toISOString()
+    })
+
+    await removeTrainingPack('pack-1')
+
+    expect(await getTrainingPack('pack-1')).toBeUndefined()
+    expect(await getProgress('pack-1')).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- add `listTrainingPacks()` repository API for story-library consumers
- add `removeTrainingPack()` repository API that also clears associated progress records
- extend db repository tests with list order and remove+progress cleanup coverage

## Verification
- npm run ci

Closes #21
