### PR TITLE
feat(stories): add progress rewind/reset controls

### DIFF
--- a/src/routes/StoriesPage.tsx
+++ b/src/routes/StoriesPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { ImportControls } from '../components/ImportControls'
-import { removeProgress } from '../db/repositories/progressRepo'
+import { getProgress, removeProgress, saveProgress } from '../db/repositories/progressRepo'
 import { listTrainingPacks, removeTrainingPack, saveTrainingPack } from '../db/repositories/trainingPackRepo'
 import type { TrainingPack } from '../db/schema'
 import { parsePdfFile } from '../ingestion/pdfParser'
@@ -26,12 +26,21 @@ async function parseImportFile(file: File): Promise<string> {
 
 export function StoriesPage() {
   const [stories, setStories] = useState<TrainingPack[]>([])
+  const [progressByStoryId, setProgressByStoryId] = useState<Record<string, number>>({})
   const [error, setError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
 
   async function refreshStories() {
-    const packs = await listTrainingPacks()
-    setStories(packs.filter((story) => story.sentences.length > 0))
+    const packs = (await listTrainingPacks()).filter((story) => story.sentences.length > 0)
+    const progressEntries = await Promise.all(
+      packs.map(async (story) => {
+        const progress = await getProgress(story.id)
+        return [story.id, progress?.sentenceIndex ?? 0] as const
+      })
+    )
+
+    setStories(packs)
+    setProgressByStoryId(Object.fromEntries(progressEntries))
   }
 
   useEffect(() => {
@@ -39,10 +48,7 @@ export function StoriesPage() {
 
     const load = async () => {
       try {
-        const packs = await listTrainingPacks()
-        if (!cancelled) {
-          setStories(packs.filter((story) => story.sentences.length > 0))
-        }
+        await refreshStories()
       } catch (loadError) {
         if (!cancelled) {
           setError('Story list loading failed.')
@@ -125,26 +131,79 @@ export function StoriesPage() {
                     <p>
                       {story.sentences.length} sentence{story.sentences.length === 1 ? '' : 's'}
                     </p>
+                    <p>
+                      Progress: {Math.min((progressByStoryId[story.id] ?? 0) + 1, story.sentences.length)}/{story.sentences.length}
+                    </p>
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      void (async () => {
-                        try {
-                          await removeTrainingPack(story.id)
-                          await removeProgress(story.id)
-                          await refreshStories()
-                          logEvent('stories', 'removed', { storyId: story.id, title: story.title })
-                        } catch (removeError) {
-                          setError('Story removal failed.')
-                          logError('stories', 'remove_failed', removeError, { storyId: story.id })
-                        }
-                      })()
-                    }}
-                    aria-label={`Remove ${story.title}`}
-                  >
-                    Remove
-                  </button>
+                  <div className="story-item-actions">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void (async () => {
+                          try {
+                            const persisted = await getProgress(story.id)
+                            const currentIndex = persisted?.sentenceIndex ?? 0
+                            const rewoundIndex = Math.max(0, currentIndex - 1)
+                            await saveProgress({
+                              packId: story.id,
+                              sentenceIndex: rewoundIndex,
+                              updatedAt: new Date().toISOString()
+                            })
+                            await refreshStories()
+                            logEvent('stories', 'progress_rewound', {
+                              storyId: story.id,
+                              title: story.title,
+                              fromSentenceIndex: currentIndex,
+                              toSentenceIndex: rewoundIndex
+                            })
+                          } catch (rewindError) {
+                            setError('Story progress rewind failed.')
+                            logError('stories', 'progress_rewind_failed', rewindError, { storyId: story.id })
+                          }
+                        })()
+                      }}
+                      aria-label={`Rewind ${story.title}`}
+                    >
+                      Rewind 1
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void (async () => {
+                          try {
+                            await removeProgress(story.id)
+                            await refreshStories()
+                            logEvent('stories', 'progress_reset', { storyId: story.id, title: story.title })
+                          } catch (resetError) {
+                            setError('Story progress reset failed.')
+                            logError('stories', 'progress_reset_failed', resetError, { storyId: story.id })
+                          }
+                        })()
+                      }}
+                      aria-label={`Reset progress for ${story.title}`}
+                    >
+                      Reset progress
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void (async () => {
+                          try {
+                            await removeTrainingPack(story.id)
+                            await removeProgress(story.id)
+                            await refreshStories()
+                            logEvent('stories', 'removed', { storyId: story.id, title: story.title })
+                          } catch (removeError) {
+                            setError('Story removal failed.')
+                            logError('stories', 'remove_failed', removeError, { storyId: story.id })
+                          }
+                        })()
+                      }}
+                      aria-label={`Remove ${story.title}`}
+                    >
+                      Remove
+                    </button>
+                  </div>
                 </li>
               ))}
             </ul>

--- a/src/styles.css
+++ b/src/styles.css
@@ -337,6 +337,13 @@ body {
   cursor: pointer;
 }
 
+.story-item-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  justify-content: flex-end;
+}
+
 .model-test-phrase {
   display: grid;
   gap: 0.35rem;

--- a/tests/e2e/story-progress-controls.spec.ts
+++ b/tests/e2e/story-progress-controls.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from './guardedTest'
+
+test('story progress can be rewound and reset from Stories view', async ({ page }) => {
+  const fileName = 'story-progress-controls.txt'
+  await page.goto('/stories')
+
+  await page.getByLabel('Import File').setInputFiles({
+    name: fileName,
+    mimeType: 'text/plain',
+    buffer: Buffer.from('Yksi. Kaksi. Kolme.', 'utf8')
+  })
+
+  const storyItem = page.locator('.story-list-item', { hasText: 'story-progress-controls' })
+  await expect(storyItem).toBeVisible()
+  await expect(storyItem).toContainText('Progress: 1/3')
+
+  await page.getByRole('link', { name: /back to play/i }).click()
+  await page.getByRole('radio', { name: /story-progress-controls/i }).click()
+  await page.getByRole('button', { name: 'Aloita' }).click()
+
+  await expect(page.getByText(/story-progress-controls: 1\/3/i)).toBeVisible()
+  await page.getByRole('button', { name: /skip sentence/i }).click()
+  await page.getByRole('button', { name: /skip sentence/i }).click()
+  await expect(page.getByText(/story-progress-controls: 3\/3/i)).toBeVisible()
+
+  await page.getByRole('link', { name: 'Stories' }).click()
+  await expect(storyItem).toContainText('Progress: 3/3')
+
+  await storyItem.getByRole('button', { name: /rewind story-progress-controls/i }).click()
+  await expect(storyItem).toContainText('Progress: 2/3')
+
+  await storyItem.getByRole('button', { name: /reset progress for story-progress-controls/i }).click()
+  await expect(storyItem).toContainText('Progress: 1/3')
+})

--- a/tests/unit/stories-page.test.tsx
+++ b/tests/unit/stories-page.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
 import { AppRoutes } from '../../src/routes/AppRoutes'
+import { getProgress, saveProgress } from '../../src/db/repositories/progressRepo'
+import { listTrainingPacks } from '../../src/db/repositories/trainingPackRepo'
 
 describe('Stories page', () => {
   it('shows story management controls on /stories and not on /play', () => {
@@ -46,6 +48,46 @@ describe('Stories page', () => {
 
     await waitFor(() => {
       expect(screen.queryByText(storyName)).not.toBeInTheDocument()
+    })
+  })
+
+  it('rewinds and resets imported story progress', async () => {
+    const user = userEvent.setup()
+    const storyName = `oma-edistyminen-${Date.now()}`
+
+    render(
+      <MemoryRouter initialEntries={['/stories']}>
+        <AppRoutes />
+      </MemoryRouter>
+    )
+
+    const input = screen.getByLabelText(/import file/i)
+    const file = new File(['Kissa nukkuu. Koira juoksee. Lintu lentaa.'], `${storyName}.txt`, { type: 'text/plain' })
+    await user.upload(input, file)
+    await screen.findByText(storyName)
+
+    const story = (await listTrainingPacks()).find((pack) => pack.title === storyName)
+    expect(story).toBeDefined()
+    if (!story) {
+      return
+    }
+
+    await saveProgress({
+      packId: story.id,
+      sentenceIndex: 2,
+      updatedAt: new Date().toISOString()
+    })
+
+    await user.click(screen.getByRole('button', { name: new RegExp(`rewind ${storyName}`, 'i') }))
+    await waitFor(async () => {
+      const progress = await getProgress(story.id)
+      expect(progress?.sentenceIndex).toBe(1)
+    })
+
+    await user.click(screen.getByRole('button', { name: new RegExp(`reset progress for ${storyName}`, 'i') }))
+    await waitFor(async () => {
+      const progress = await getProgress(story.id)
+      expect(progress?.sentenceIndex ?? 0).toBe(0)
     })
   })
 })


### PR DESCRIPTION
## Summary
- add per-story progress display in Stories view
- add Rewind 1 action (clamped to index 0)
- add Reset progress action (clears stored progress)
- keep local-first persistence via progress repository
- add unit + e2e regression coverage

## Verification
- npm run test:unit -- tests/unit/stories-page.test.tsx
- npm run test:e2e -- tests/e2e/story-progress-controls.spec.ts --project=chromium
- npm run test:unit