### PR TITLE
feat(pwa): explicit runtime cache strategy for offline hardening

### DIFF
--- a/tests/unit/offline-hardening.test.ts
+++ b/tests/unit/offline-hardening.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import { shouldServeFromCache } from '../../src/offline/cachePolicy'
 
@@ -10,5 +11,14 @@ describe('Cache policy', () => {
   it('normalizes query/hash paths before cache decision', () => {
     expect(shouldServeFromCache('/assets/main.js?v=1#chunk')).toBe(true)
     expect(shouldServeFromCache('/play?from=home')).toBe(true)
+  })
+
+  it('defines deterministic workbox runtime caching for pages and static assets', () => {
+    const config = fs.readFileSync('vite.config.ts', 'utf8')
+    expect(config).toMatch(/runtimeCaching:\s*\[/)
+    expect(config).toMatch(/handler:\s*'NetworkFirst'/)
+    expect(config).toMatch(/handler:\s*'StaleWhileRevalidate'/)
+    expect(config).toMatch(/cacheName:\s*'kuupeli-pages'/)
+    expect(config).toMatch(/cacheName:\s*'kuupeli-assets'/)
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,32 @@ export default defineConfig(() => {
         registerType: 'autoUpdate',
         includeAssets: ['icons/icon-192.png', 'icons/icon-512.png'],
         workbox: {
-          maximumFileSizeToCacheInBytes: 25 * 1024 * 1024
+          maximumFileSizeToCacheInBytes: 25 * 1024 * 1024,
+          runtimeCaching: [
+            {
+              urlPattern: ({ request }) => request.mode === 'navigate',
+              handler: 'NetworkFirst',
+              options: {
+                cacheName: 'kuupeli-pages',
+                networkTimeoutSeconds: 3,
+                expiration: {
+                  maxEntries: 30,
+                  maxAgeSeconds: 24 * 60 * 60
+                }
+              }
+            },
+            {
+              urlPattern: ({ url }) => url.pathname.includes('/assets/') || url.pathname.includes('/icons/'),
+              handler: 'StaleWhileRevalidate',
+              options: {
+                cacheName: 'kuupeli-assets',
+                expiration: {
+                  maxEntries: 100,
+                  maxAgeSeconds: 30 * 24 * 60 * 60
+                }
+              }
+            }
+          ]
         },
         manifest: {
           name: 'Kuupeli',


### PR DESCRIPTION
## Summary
- configure Workbox runtime caching in `vite.config.ts` for deterministic offline behavior
- add navigation route cache (`NetworkFirst`) with timeout/expiration
- add static asset cache (`StaleWhileRevalidate`) with bounded retention
- extend offline hardening unit tests to guard these strategies

## Verification
- `npm run test:unit -- tests/unit/offline-hardening.test.ts tests/unit/vite-pages-base.test.ts`
- `npm run test:unit`

## Note
- `npm run build` currently fails on an existing baseline TypeScript issue in `tests/unit/stop-audio-button.test.tsx` (unrelated to this PR)
