### PR TITLE
feat(stories): actionable txt/pdf import error guidance

### DIFF
--- a/src/routes/StoriesPage.tsx
+++ b/src/routes/StoriesPage.tsx
@@ -24,6 +24,23 @@ async function parseImportFile(file: File): Promise<string> {
   return isPdf ? parsePdfFile(file) : parseTxtFile(file)
 }
 
+function importFailureMessage(file: File, error: unknown): string {
+  const isPdf = file.type === 'application/pdf' || file.name.toLocaleLowerCase('fi-FI').endsWith('.pdf')
+  if (isPdf) {
+    return 'Could not import PDF. Try another PDF export or convert the document to TXT.'
+  }
+
+  if (file.name.toLocaleLowerCase('fi-FI').endsWith('.txt') || file.type.startsWith('text/')) {
+    return 'Could not import TXT. Verify the file is readable plain text and try again.'
+  }
+
+  if (error instanceof Error && error.message) {
+    return `Story import failed: ${error.message}`
+  }
+
+  return 'Story import failed.'
+}
+
 export function StoriesPage() {
   const [stories, setStories] = useState<TrainingPack[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -101,7 +118,7 @@ export function StoriesPage() {
                   sentenceCount: story.sentences.length
                 })
               } catch (importError) {
-                setError('Story import failed.')
+                setError(importFailureMessage(file, importError))
                 logError('stories', 'import_failed', importError, { fileName: file.name })
               } finally {
                 setIsLoading(false)

--- a/tests/unit/stories-page.test.tsx
+++ b/tests/unit/stories-page.test.tsx
@@ -48,4 +48,33 @@ describe('Stories page', () => {
       expect(screen.queryByText(storyName)).not.toBeInTheDocument()
     })
   })
+
+  it('shows actionable error guidance when txt parsing fails', async () => {
+    const user = userEvent.setup()
+    const originalText = File.prototype.text
+
+    Object.defineProperty(File.prototype, 'text', {
+      configurable: true,
+      value: async () => {
+        throw new Error('simulated txt read failure')
+      }
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/stories']}>
+        <AppRoutes />
+      </MemoryRouter>
+    )
+
+    const input = screen.getByLabelText(/import file/i)
+    const file = new File(['broken'], `broken-${Date.now()}.txt`, { type: 'text/plain' })
+    await user.upload(input, file)
+
+    await expect(screen.findByRole('alert')).resolves.toHaveTextContent(/could not import txt/i)
+
+    Object.defineProperty(File.prototype, 'text', {
+      configurable: true,
+      value: originalText
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- replace generic story import failure message with actionable guidance
- provide file-type-specific error text for TXT vs PDF imports
- keep parser/logging path unchanged while improving user recovery direction
- add unit coverage for TXT parse-failure guidance

## Verification
- npm run test:unit -- tests/unit/stories-page.test.tsx
- npm run test:unit