### PR TITLE
feat(models): snapshot and enforce Finnish Piper voice coverage

### DIFF
--- a/docs/model-manager.md
+++ b/docs/model-manager.md
@@ -13,3 +13,13 @@ Kuupeli uses a curated local TTS model catalog.
 
 ## Storage
 Installed model metadata is persisted in browser local storage for now.
+
+## Finnish Piper Coverage (Snapshot: 2026-03-03)
+- Available browser-WASM Finnish Piper voices in current upstream catalog:
+  - `fi_FI-harri-low`
+  - `fi_FI-harri-medium`
+- Higher Finnish quality tiers (for example `high`) are currently unavailable in the upstream voice list used by Kuupeli.
+
+Primary sources:
+- https://huggingface.co/rhasspy/piper-voices/tree/main/fi/fi_FI/harri
+- https://github.com/Mintplex-Labs/piper-tts-web

--- a/src/components/ModelManagerPanel.tsx
+++ b/src/components/ModelManagerPanel.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
-import { MODEL_CATALOG } from '../models/catalog'
+import {
+  FINNISH_PIPER_AVAILABLE_VOICE_IDS,
+  FINNISH_PIPER_UNAVAILABLE_HIGHER_TIERS,
+  FINNISH_PIPER_VOICE_CATALOG_SNAPSHOT_DATE,
+  MODEL_CATALOG
+} from '../models/catalog'
 import {
   getActiveModel,
   getModelVoiceType,
@@ -61,6 +66,11 @@ export function ModelManagerPanel() {
       <p>
         Manage local speech models used by Kuupeli. Downloadable Piper voices are stored on device and can be removed
         later.
+      </p>
+      <p>
+        Finnish Piper catalog snapshot ({FINNISH_PIPER_VOICE_CATALOG_SNAPSHOT_DATE}):{' '}
+        {FINNISH_PIPER_AVAILABLE_VOICE_IDS.join(', ')}. Higher Finnish tiers currently unavailable:{' '}
+        {FINNISH_PIPER_UNAVAILABLE_HIGHER_TIERS.join(', ')}.
       </p>
       {storageError && <p role="alert">{storageError}</p>}
       <label className="model-test-phrase">

--- a/src/models/catalog.ts
+++ b/src/models/catalog.ts
@@ -20,6 +20,10 @@ export interface ModelCatalogEntry {
   voiceTypes: VoiceTypeOption[]
 }
 
+export const FINNISH_PIPER_VOICE_CATALOG_SNAPSHOT_DATE = '2026-03-03'
+export const FINNISH_PIPER_AVAILABLE_VOICE_IDS = ['fi_FI-harri-low', 'fi_FI-harri-medium'] as const
+export const FINNISH_PIPER_UNAVAILABLE_HIGHER_TIERS = ['high'] as const
+
 export const MODEL_CATALOG: ModelCatalogEntry[] = [
   {
     id: 'fi-starter-small',

--- a/tests/unit/model-manager.test.ts
+++ b/tests/unit/model-manager.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  FINNISH_PIPER_AVAILABLE_VOICE_IDS,
+  FINNISH_PIPER_UNAVAILABLE_HIGHER_TIERS
+} from '../../src/models/catalog'
+import {
   getModelVoiceType,
   installModel,
   listAvailableModels,
@@ -23,6 +27,15 @@ describe('Model manager', () => {
     expect(models.some((model) => model.id === 'fi-starter-small')).toBe(true)
     expect(models.some((model) => model.id === 'fi-piper-harri-low')).toBe(true)
     expect(models.some((model) => model.id === 'fi-piper-harri-medium')).toBe(true)
+
+    const finnishPiperVoiceIds = models
+      .filter((model) => model.engine === 'piper-web' && model.piperVoiceId?.startsWith('fi_FI-'))
+      .map((model) => model.piperVoiceId)
+      .filter((voiceId): voiceId is string => Boolean(voiceId))
+      .sort()
+    expect(finnishPiperVoiceIds).toEqual([...FINNISH_PIPER_AVAILABLE_VOICE_IDS].sort())
+    expect(models.some((model) => model.qualityTier === 'high' && model.piperVoiceId?.startsWith('fi_FI-'))).toBe(false)
+    expect(FINNISH_PIPER_UNAVAILABLE_HIGHER_TIERS).toContain('high')
   })
 
   it('installs downloadable model and can remove it', async () => {

--- a/tests/unit/widgets/model-manager-panel.test.tsx
+++ b/tests/unit/widgets/model-manager-panel.test.tsx
@@ -18,6 +18,7 @@ describe('ModelManagerPanel', () => {
 
     expect(screen.getByRole('heading', { name: /model manager/i })).toBeInTheDocument()
     expect(screen.getByText(/manage local speech models used by kuupeli/i)).toBeInTheDocument()
+    expect(screen.getByText(/finnish piper catalog snapshot/i)).toBeInTheDocument()
     expect(await screen.findByText(/finnish starter small/i)).toBeInTheDocument()
     expect(screen.getByText(/finnish harri low \(piper\)/i)).toBeInTheDocument()
     expect(screen.getByText(/finnish harri medium \(piper\)/i)).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- add explicit Finnish Piper catalog snapshot constants in model catalog
- surface Finnish coverage + unavailable higher-tier note in Model Manager UI
- add regression assertions that Finnish Piper voice coverage remains `fi_FI-harri-low` + `fi_FI-harri-medium`
- document source-backed constraints in `docs/model-manager.md`

## Verification
- npm run test:unit -- tests/unit/model-manager.test.ts tests/unit/widgets/model-manager-panel.test.tsx tests/unit/docs-readme.test.ts
- npm run ci

Refs: #26
