### PR TITLE
fix(pages): harden deep-link routing with static 404 fallback

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kuupeli Redirect</title>
+  </head>
+  <body>
+    <script>
+      (function () {
+        var segments = window.location.pathname.split('/').filter(Boolean)
+        var base = segments.length > 0 ? '/' + segments[0] + '/' : '/'
+        var relative = '/' + segments.slice(1).join('/')
+        var fullPath = relative + window.location.search + window.location.hash
+        var target = base + '?ghp_path=' + encodeURIComponent(fullPath)
+        window.location.replace(target)
+      })()
+    </script>
+  </body>
+</html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { logError, logEvent } from './observability/devLogger'
 import { registerServiceWorker } from './pwa/registerServiceWorker'
+import { restorePathFromGhPagesFallback } from './routing/ghPagesFallback'
 import { AppRoutes } from './routes/AppRoutes'
 import './styles.css'
 
@@ -14,6 +15,8 @@ if (!container) {
 }
 
 logEvent('app_boot', 'starting_render')
+
+restorePathFromGhPagesFallback(window.location, window.history, import.meta.env.BASE_URL)
 
 registerServiceWorker({
   isProduction: import.meta.env.PROD,

--- a/src/routing/ghPagesFallback.ts
+++ b/src/routing/ghPagesFallback.ts
@@ -1,0 +1,37 @@
+import { logError, logEvent } from '../observability/devLogger'
+
+const GHP_PATH_QUERY_KEY = 'ghp_path'
+
+function normalizeBase(baseUrl: string): string {
+  if (!baseUrl || baseUrl === '/') {
+    return '/'
+  }
+
+  return baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
+}
+
+function buildTargetUrl(baseUrl: string, relativePath: string): string {
+  const normalizedBase = normalizeBase(baseUrl)
+  const trimmedRelative = relativePath.startsWith('/') ? relativePath.slice(1) : relativePath
+  return `${normalizedBase}${trimmedRelative}`
+}
+
+export function restorePathFromGhPagesFallback(location: Location, history: History, baseUrl: string): void {
+  const searchParams = new URLSearchParams(location.search)
+  const encodedPath = searchParams.get(GHP_PATH_QUERY_KEY)
+
+  if (!encodedPath) {
+    return
+  }
+
+  try {
+    const decodedPath = decodeURIComponent(encodedPath)
+    const normalizedPath = decodedPath.startsWith('/') ? decodedPath : `/${decodedPath}`
+    const targetUrl = buildTargetUrl(baseUrl, normalizedPath)
+
+    history.replaceState(null, '', targetUrl)
+    logEvent('routing', 'gh_pages_fallback_restored', { targetUrl })
+  } catch (error) {
+    logError('routing', 'gh_pages_fallback_restore_failed', error, { encodedPath })
+  }
+}

--- a/tests/unit/deploy-workflow.test.ts
+++ b/tests/unit/deploy-workflow.test.ts
@@ -11,4 +11,10 @@ describe('GitHub Pages deploy workflow', () => {
     expect(workflow).toMatch(/publish_branch:\s+gh-pages/)
     expect(workflow).toMatch(/publish_dir:\s+\.\/dist/)
   })
+
+  it('commits SPA fallback page for project-page deep links', () => {
+    const fallback = fs.readFileSync('public/404.html', 'utf8')
+    expect(fallback).toMatch(/ghp_path/)
+    expect(fallback).toMatch(/window\.location\.replace/)
+  })
 })

--- a/tests/unit/gh-pages-fallback.test.ts
+++ b/tests/unit/gh-pages-fallback.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { restorePathFromGhPagesFallback } from '../../src/routing/ghPagesFallback'
+
+describe('GitHub Pages fallback routing', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('restores deep route from ghp_path query for BrowserRouter basename', () => {
+    const replaceState = vi.fn()
+    const mockLocation = {
+      search: '?ghp_path=%2Fplay%3Fstory%3Ddemo%23line2'
+    } as Location
+
+    restorePathFromGhPagesFallback(mockLocation, { replaceState } as unknown as History, '/kuupeli/')
+
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/kuupeli/play?story=demo#line2')
+  })
+
+  it('does nothing when fallback query is missing', () => {
+    const replaceState = vi.fn()
+    const mockLocation = { search: '' } as Location
+
+    restorePathFromGhPagesFallback(mockLocation, { replaceState } as unknown as History, '/kuupeli/')
+
+    expect(replaceState).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/router-basename.test.ts
+++ b/tests/unit/router-basename.test.ts
@@ -5,5 +5,6 @@ describe('Router basename configuration', () => {
   it('sets BrowserRouter basename from Vite BASE_URL', () => {
     const source = fs.readFileSync('src/main.tsx', 'utf8')
     expect(source).toMatch(/<BrowserRouter basename=\{import\.meta\.env\.BASE_URL\}>/)
+    expect(source).toMatch(/restorePathFromGhPagesFallback\(window\.location, window\.history, import\.meta\.env\.BASE_URL\)/)
   })
 })


### PR DESCRIPTION
## Summary
- add committed `public/404.html` fallback page that redirects GitHub Pages deep-link misses back to app root
- add startup restore logic in `main.tsx` to recover original route from `ghp_path`
- add unit tests for fallback restore logic and workflow regression checks

## Verification
- npm run test:unit -- tests/unit/gh-pages-fallback.test.ts tests/unit/router-basename.test.ts tests/unit/deploy-workflow.test.ts
- npm run ci

Refs: #7
