### PR TITLE
feat(ingestion): complete txt/pdf parsing and import guidance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@mintplex-labs/piper-tts-web": "^1.0.4",
         "espeak-ng": "^1.0.2",
         "idb": "^8.0.3",
+        "pdfjs-dist": "^4.10.38",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.13.1"
@@ -2272,6 +2273,256 @@
       "license": "MIT",
       "peerDependencies": {
         "onnxruntime-web": "^1.18.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.95.tgz",
+      "integrity": "sha512-lkg23ge+rgyhgUwXmlbkPEhuhHq/hUi/gXKH+4I7vO+lJrbNfEYcQdJLIGjKyXLQzgFiiyDAwh5vAe/tITAE+w==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.95",
+        "@napi-rs/canvas-darwin-arm64": "0.1.95",
+        "@napi-rs/canvas-darwin-x64": "0.1.95",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.95",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.95",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.95",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.95",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.95",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.95",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.95",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.95"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.95.tgz",
+      "integrity": "sha512-SqTh0wsYbetckMXEvHqmR7HKRJujVf1sYv1xdlhkifg6TlCSysz1opa49LlS3+xWuazcQcfRfmhA07HxxxGsAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.95.tgz",
+      "integrity": "sha512-F7jT0Syu+B9DGBUBcMk3qCRIxAWiDXmvEjamwbYfbZl7asI1pmXZUnCOoIu49Wt0RNooToYfRDxU9omD6t5Xuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.95.tgz",
+      "integrity": "sha512-54eb2Ho15RDjYGXO/harjRznBrAvu+j5nQ85Z4Qd6Qg3slR8/Ja+Yvvy9G4yo7rdX6NR9GPkZeSTf2UcKXwaXw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.95.tgz",
+      "integrity": "sha512-hYaLCSLx5bmbnclzQc3ado3PgZ66blJWzjXp0wJmdwpr/kH+Mwhj6vuytJIomgksyJoCdIqIa4N6aiqBGJtJ5Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.95.tgz",
+      "integrity": "sha512-J7VipONahKsmScPZsipHVQBqpbZx4favaD8/enWzzlGcjiwycOoymL7f4tNeqdjK0su19bDOUt6mjp9gsPWYlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.95.tgz",
+      "integrity": "sha512-PXy0UT1J/8MPG8UAkWp6Fd51ZtIZINFzIjGH909JjQrtCuJf3X6nanHYdz1A+Wq9o4aoPAw1YEUpFS1lelsVlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.95.tgz",
+      "integrity": "sha512-2IzCkW2RHRdcgF9W5/plHvYFpc6uikyjMb5SxjqmNxfyDFz9/HB89yhi8YQo0SNqrGRI7yBVDec7Pt+uMyRWsg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.95.tgz",
+      "integrity": "sha512-OV/ol/OtcUr4qDhQg8G7SdViZX8XyQeKpPsVv/j3+7U178FGoU4M+yIocdVo1ih/A8GQ63+LjF4jDoEjaVU8Pw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.95.tgz",
+      "integrity": "sha512-Z5KzqBK/XzPz5+SFHKz7yKqClEQ8pOiEDdgk5SlphBLVNb8JFIJkxhtJKSvnJyHh2rjVgiFmvtJzMF0gNwwKyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.95.tgz",
+      "integrity": "sha512-aj0YbRpe8qVJ4OzMsK7NfNQePgcf9zkGFzNZ9mSuaxXzhpLHmlF2GivNdCdNOg8WzA/NxV6IU4c5XkXadUMLeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.95",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.95.tgz",
+      "integrity": "sha512-GA8leTTCfdjuHi8reICTIxU0081PhXvl3lzIniLUjeLACx9GubUiyzkwFb+oyeKLS5IAGZFLKnzAf4wm2epRlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@playwright/test": {
@@ -5524,6 +5775,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mintplex-labs/piper-tts-web": "^1.0.4",
     "espeak-ng": "^1.0.2",
     "idb": "^8.0.3",
+    "pdfjs-dist": "^4.10.38",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.13.1"

--- a/src/ingestion/pdfParser.ts
+++ b/src/ingestion/pdfParser.ts
@@ -1,5 +1,10 @@
 import { logEvent } from '../observability/devLogger'
 
+type PdfJsModule = typeof import('pdfjs-dist/legacy/build/pdf.mjs')
+type PdfTextItem = { str?: string }
+
+let pdfJsModulePromise: Promise<PdfJsModule> | null = null
+
 function readAsArrayBufferWithFileReader(file: File): Promise<ArrayBuffer> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
@@ -13,11 +18,48 @@ function readAsArrayBufferWithFileReader(file: File): Promise<ArrayBuffer> {
   })
 }
 
+async function getPdfJsModule(): Promise<PdfJsModule> {
+  if (!pdfJsModulePromise) {
+    pdfJsModulePromise = import('pdfjs-dist/legacy/build/pdf.mjs')
+  }
+
+  return pdfJsModulePromise
+}
+
 export async function parsePdfFile(file: File): Promise<string> {
-  // Placeholder implementation for v1 scaffolding; full PDF extraction lands in later task work.
   logEvent('ingestion_pdf', 'parse_started', { fileName: file.name, fileSize: file.size })
   const bytes = typeof file.arrayBuffer === 'function' ? await file.arrayBuffer() : await readAsArrayBufferWithFileReader(file)
-  const text = new TextDecoder().decode(bytes)
-  logEvent('ingestion_pdf', 'parse_completed', { byteLength: bytes.byteLength, characterCount: text.length })
+  const pdfjs = await getPdfJsModule()
+  const loadingTask = pdfjs.getDocument({
+    data: new Uint8Array(bytes),
+    disableWorker: true
+  })
+  const documentProxy = await loadingTask.promise
+  const pages: string[] = []
+
+  for (let pageIndex = 1; pageIndex <= documentProxy.numPages; pageIndex += 1) {
+    const page = await documentProxy.getPage(pageIndex)
+    const content = await page.getTextContent()
+    const line = content.items
+      .map((item) => {
+        const maybeText = item as PdfTextItem
+        return typeof maybeText.str === 'string' ? maybeText.str : ''
+      })
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+
+    if (line.length > 0) {
+      pages.push(line)
+    }
+  }
+
+  const text = pages.join('\n')
+  logEvent('ingestion_pdf', 'parse_completed', {
+    byteLength: bytes.byteLength,
+    pageCount: documentProxy.numPages,
+    characterCount: text.length
+  })
+  await documentProxy.destroy()
   return text
 }

--- a/src/ingestion/pdfParser.ts
+++ b/src/ingestion/pdfParser.ts
@@ -31,8 +31,7 @@ export async function parsePdfFile(file: File): Promise<string> {
   const bytes = typeof file.arrayBuffer === 'function' ? await file.arrayBuffer() : await readAsArrayBufferWithFileReader(file)
   const pdfjs = await getPdfJsModule()
   const loadingTask = pdfjs.getDocument({
-    data: new Uint8Array(bytes),
-    disableWorker: true
+    data: new Uint8Array(bytes)
   })
   const documentProxy = await loadingTask.promise
   const pages: string[] = []

--- a/src/routes/StoriesPage.tsx
+++ b/src/routes/StoriesPage.tsx
@@ -24,6 +24,23 @@ async function parseImportFile(file: File): Promise<string> {
   return isPdf ? parsePdfFile(file) : parseTxtFile(file)
 }
 
+function importFailureMessage(file: File, error: unknown): string {
+  const isPdf = file.type === 'application/pdf' || file.name.toLocaleLowerCase('fi-FI').endsWith('.pdf')
+  if (isPdf) {
+    return 'Could not import PDF. Try another PDF export or convert the document to TXT.'
+  }
+
+  if (file.name.toLocaleLowerCase('fi-FI').endsWith('.txt') || file.type.startsWith('text/')) {
+    return 'Could not import TXT. Verify the file is readable plain text and try again.'
+  }
+
+  if (error instanceof Error && error.message) {
+    return `Story import failed: ${error.message}`
+  }
+
+  return 'Story import failed.'
+}
+
 export function StoriesPage() {
   const [stories, setStories] = useState<TrainingPack[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -101,7 +118,7 @@ export function StoriesPage() {
                   sentenceCount: story.sentences.length
                 })
               } catch (importError) {
-                setError('Story import failed.')
+                setError(importFailureMessage(file, importError))
                 logError('stories', 'import_failed', importError, { fileName: file.name })
               } finally {
                 setIsLoading(false)

--- a/tests/unit/pdf-parser.test.ts
+++ b/tests/unit/pdf-parser.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { parsePdfFile } from '../../src/ingestion/pdfParser'
+
+const mocks = vi.hoisted(() => ({
+  getDocument: vi.fn()
+}))
+
+vi.mock('pdfjs-dist/legacy/build/pdf.mjs', () => ({
+  getDocument: mocks.getDocument
+}))
+
+describe('PDF parser', () => {
+  beforeEach(() => {
+    mocks.getDocument.mockReset()
+  })
+
+  it('extracts page text in original order', async () => {
+    const getPage = vi
+      .fn()
+      .mockResolvedValueOnce({
+        getTextContent: vi.fn().mockResolvedValue({
+          items: [{ str: 'Olipa' }, { str: 'kerran.' }]
+        })
+      })
+      .mockResolvedValueOnce({
+        getTextContent: vi.fn().mockResolvedValue({
+          items: [{ str: 'Sitten' }, { str: 'tuli' }, { str: 'ilta.' }]
+        })
+      })
+
+    const destroy = vi.fn().mockResolvedValue(undefined)
+    mocks.getDocument.mockReturnValue({
+      promise: Promise.resolve({
+        numPages: 2,
+        getPage,
+        destroy
+      })
+    })
+
+    const file = new File([new Uint8Array([1, 2, 3, 4])], 'story.pdf', { type: 'application/pdf' })
+    const text = await parsePdfFile(file)
+
+    expect(text).toBe('Olipa kerran.\nSitten tuli ilta.')
+    expect(mocks.getDocument).toHaveBeenCalledTimes(1)
+    expect(getPage).toHaveBeenCalledWith(1)
+    expect(getPage).toHaveBeenCalledWith(2)
+    expect(destroy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/stories-page.test.tsx
+++ b/tests/unit/stories-page.test.tsx
@@ -48,4 +48,33 @@ describe('Stories page', () => {
       expect(screen.queryByText(storyName)).not.toBeInTheDocument()
     })
   })
+
+  it('shows actionable error guidance when txt parsing fails', async () => {
+    const user = userEvent.setup()
+    const originalText = File.prototype.text
+
+    Object.defineProperty(File.prototype, 'text', {
+      configurable: true,
+      value: async () => {
+        throw new Error('simulated txt read failure')
+      }
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/stories']}>
+        <AppRoutes />
+      </MemoryRouter>
+    )
+
+    const input = screen.getByLabelText(/import file/i)
+    const file = new File(['broken'], `broken-${Date.now()}.txt`, { type: 'text/plain' })
+    await user.upload(input, file)
+
+    await expect(screen.findByRole('alert')).resolves.toHaveTextContent(/could not import txt/i)
+
+    Object.defineProperty(File.prototype, 'text', {
+      configurable: true,
+      value: originalText
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- replace placeholder PDF byte decode parser with real `pdfjs-dist` extraction in page order
- add parser coverage for ordered multi-page extraction
- improve Stories import errors with actionable TXT/PDF-specific guidance
- keep sentence splitting and storage flow unchanged
- include a small compatibility fix for current `pdfjs-dist` v4 typings (remove unsupported `disableWorker` init property)

## Notes
- This consolidates the ingestion work previously split between #36 and #41 onto latest `main`.

## Verification
- `npm run ci`

Refs: KUU-7
Refs: KUU-31
