### PR TITLE
test(widgets): cover retry feedback and storage error banner

### DIFF
--- a/tests/unit/widgets/retry-feedback.test.tsx
+++ b/tests/unit/widgets/retry-feedback.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { RetryFeedback } from '../../../src/components/RetryFeedback'
+
+describe('RetryFeedback', () => {
+  it('shows success state when no invalid indexes exist', () => {
+    render(<RetryFeedback invalidIndexes={[]} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('All words are correct.')
+  })
+
+  it('shows invalid index list when corrections are needed', () => {
+    render(<RetryFeedback invalidIndexes={[1, 4, 6]} />)
+
+    expect(screen.getByRole('status')).toHaveTextContent('Fix highlighted words: 1, 4, 6')
+  })
+})

--- a/tests/unit/widgets/storage-error-banner.test.tsx
+++ b/tests/unit/widgets/storage-error-banner.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { StorageErrorBanner } from '../../../src/components/StorageErrorBanner'
+
+describe('StorageErrorBanner', () => {
+  it('renders alert message when error text exists', () => {
+    render(<StorageErrorBanner message="IndexedDB unavailable" />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Storage issue: IndexedDB unavailable')
+  })
+
+  it('renders nothing when message is empty', () => {
+    const { container } = render(<StorageErrorBanner message="" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})


### PR DESCRIPTION
## Summary
- add direct unit coverage for `StorageErrorBanner`
- add direct unit coverage for `RetryFeedback`
- verify empty/error and success/fix-needed render states

## Why
These were the remaining untested widget components in the current UI set. This tightens the widget-level functional testing mandate.

## Verification
- `npm run test:unit -- tests/unit/widgets/storage-error-banner.test.tsx tests/unit/widgets/retry-feedback.test.tsx`
- `npm run test:unit`
- `npm run ci`

Refs: KUU-16
